### PR TITLE
Add documentation

### DIFF
--- a/.github/workflows/goreadme.yml
+++ b/.github/workflows/goreadme.yml
@@ -1,0 +1,22 @@
+name: Goreadme
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  goreadme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update README.md according to Go Doc
+        uses: posener/goreadme@v1
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/goreadme.yml
+++ b/.github/workflows/goreadme.yml
@@ -19,4 +19,10 @@ jobs:
       - name: Update README.md according to Go Doc
         uses: posener/goreadme@v1
         with:
+          constants: true
+          factories: true
+          functions: true
+          methods: true
+          types: true
+          variabless: true
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Test
 
 on:
   push:

--- a/asciitree.go
+++ b/asciitree.go
@@ -47,7 +47,7 @@ func (t *Tree) AddBranches(titles ...string) *Tree {
 	return t
 }
 
-// AddTrees appends the provided tree node to the node's children.
+// AddTrees appends the provided tree nodes to the node's children.
 //
 // Unlike NewChild and NewChildBranch, AddTrees returns the original node for
 // chaining.

--- a/asciitree.go
+++ b/asciitree.go
@@ -49,7 +49,8 @@ func (t *Tree) AddBranches(titles ...string) *Tree {
 
 // AddTrees appends the provided tree node to the node's children.
 //
-// AddTrees returns the original node for chaining.
+// Unlike NewChild and NewChildBranch, AddTrees returns the original node for
+// chaining.
 func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	for _, tree := range trees {
 		t.children = append(t.children, tree)

--- a/asciitree.go
+++ b/asciitree.go
@@ -142,5 +142,5 @@ func (t *Tree) printChildren(prefix string) string {
 	return out
 }
 
-// Verify that tree implements fmt.Stringer:
+// Verify that Tree implements fmt.Stringer:
 var _ fmt.Stringer = (*Tree)(nil)

--- a/asciitree.go
+++ b/asciitree.go
@@ -6,37 +6,21 @@ import (
 	"strings"
 )
 
-type Tree interface {
-	fmt.Stringer
-
-	Add(...string) Tree
-	AddBranches(...string) Tree
-	AddTrees(...Tree) Tree
-	IsBranch() bool
-	NewChild(string) Tree
-	NewChildBranch(string) Tree
-	SetTitle(string) Tree
-	Sort(...SortOption) Tree
-	Title() string
-
-	printChildren(string) string
-}
-
-type tree struct {
-	children    []Tree
+type Tree struct {
+	children    []*Tree
 	forceBranch bool
 	title       string
 }
 
-func New(title string) Tree {
-	return &tree{title: title}
+func New(title string) *Tree {
+	return &Tree{title: title}
 }
 
-func NewBranch(title string) Tree {
-	return &tree{forceBranch: true, title: title}
+func NewBranch(title string) *Tree {
+	return &Tree{forceBranch: true, title: title}
 }
 
-func (t *tree) Add(titles ...string) Tree {
+func (t *Tree) Add(titles ...string) *Tree {
 	for _, title := range titles {
 		child := New(title)
 		t.children = append(t.children, child)
@@ -44,7 +28,7 @@ func (t *tree) Add(titles ...string) Tree {
 	return t
 }
 
-func (t *tree) AddBranches(titles ...string) Tree {
+func (t *Tree) AddBranches(titles ...string) *Tree {
 	for _, title := range titles {
 		child := NewBranch(title)
 		t.children = append(t.children, child)
@@ -52,35 +36,35 @@ func (t *tree) AddBranches(titles ...string) Tree {
 	return t
 }
 
-func (t *tree) AddTrees(trees ...Tree) Tree {
+func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	for _, tree := range trees {
 		t.children = append(t.children, tree)
 	}
 	return t
 }
 
-func (t *tree) IsBranch() bool {
+func (t *Tree) IsBranch() bool {
 	return t.forceBranch || len(t.children) > 0
 }
 
-func (t *tree) NewChild(title string) Tree {
+func (t *Tree) NewChild(title string) *Tree {
 	child := New(title)
 	t.children = append(t.children, child)
 	return child
 }
 
-func (t *tree) NewChildBranch(title string) Tree {
+func (t *Tree) NewChildBranch(title string) *Tree {
 	child := NewBranch(title)
 	t.children = append(t.children, child)
 	return child
 }
 
-func (t *tree) SetTitle(title string) Tree {
+func (t *Tree) SetTitle(title string) *Tree {
 	t.title = title
 	return t
 }
 
-func (t *tree) Sort(opts ...SortOption) Tree {
+func (t *Tree) Sort(opts ...SortOption) *Tree {
 	options := newSortOptions(opts...)
 	sort.SliceStable(t.children, func(i, j int) bool {
 		a := t.children[i]
@@ -96,15 +80,15 @@ func (t *tree) Sort(opts ...SortOption) Tree {
 	return t
 }
 
-func (t *tree) String() string {
+func (t *Tree) String() string {
 	return t.Title() + t.printChildren("")
 }
 
-func (t *tree) Title() string {
+func (t *Tree) Title() string {
 	return t.title
 }
 
-func (t *tree) printChildren(prefix string) string {
+func (t *Tree) printChildren(prefix string) string {
 	var out string
 	for i, child := range t.children {
 		connector := "├── "
@@ -122,5 +106,5 @@ func (t *tree) printChildren(prefix string) string {
 	return out
 }
 
-// Verify that tree implements asciitree.Tree
-var _ Tree = (*tree)(nil)
+// Verify that tree implements fmt.Stringer
+var _ fmt.Stringer = (*Tree)(nil)

--- a/asciitree.go
+++ b/asciitree.go
@@ -1,3 +1,5 @@
+// Package asciitree provides tools to build trees of entities and print them
+// using ASCII art.
 package asciitree
 
 import (

--- a/asciitree.go
+++ b/asciitree.go
@@ -6,20 +6,27 @@ import (
 	"strings"
 )
 
+// Tree represents a tree node.
 type Tree struct {
 	children    []*Tree
 	forceBranch bool
 	title       string
 }
 
+// New creates a tree node.
 func New(title string) *Tree {
 	return &Tree{title: title}
 }
 
+// New creates a tree node and forces it to be recognized as a branch.
 func NewBranch(title string) *Tree {
 	return &Tree{forceBranch: true, title: title}
 }
 
+// Add creates one or more tree nodes with the provided titles and appends them
+// to the node's children.
+//
+// Unlike NewChild, Add returns the original node for chaining.
 func (t *Tree) Add(titles ...string) *Tree {
 	for _, title := range titles {
 		child := New(title)
@@ -28,6 +35,10 @@ func (t *Tree) Add(titles ...string) *Tree {
 	return t
 }
 
+// AddBranch creates one or more tree nodes with the provided titles, forces
+// them to be recognized as branches, and appends them to the node's children.
+//
+// Unlike NewChildBranch, AddBranch returns the original node for chaining.
 func (t *Tree) AddBranches(titles ...string) *Tree {
 	for _, title := range titles {
 		child := NewBranch(title)
@@ -36,6 +47,9 @@ func (t *Tree) AddBranches(titles ...string) *Tree {
 	return t
 }
 
+// AddTrees appends the provided tree node to the node's children.
+//
+// AddTrees returns the original node for chaining.
 func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	for _, tree := range trees {
 		t.children = append(t.children, tree)
@@ -43,27 +57,46 @@ func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	return t
 }
 
+// IsBranch reports whether the node should be recognized as a branch. This is
+// possible in two cases:
+//
+// - The node has one or more children.
+// - The node was forced to be recognized as a branch by creating it with the
+// NewBranch function or the NewChildBranch method.
 func (t *Tree) IsBranch() bool {
 	return t.forceBranch || len(t.children) > 0
 }
 
+// NewChild creates a tree node and appends it to the node's children.
+//
+// Unlike Add, NewChild returns the newly created node.
 func (t *Tree) NewChild(title string) *Tree {
 	child := New(title)
 	t.children = append(t.children, child)
 	return child
 }
 
+// NewChildBranch creates a tree node, forces it to be recognized as a branch,
+// and appends it to the node's children.
+//
+// Unlike AddBranch, NewChildBranch returns the newly created node.
 func (t *Tree) NewChildBranch(title string) *Tree {
 	child := NewBranch(title)
 	t.children = append(t.children, child)
 	return child
 }
 
+// SetTitle sets the node's title.
+//
+// SetTitle returns the original node for chaining.
 func (t *Tree) SetTitle(title string) *Tree {
 	t.title = title
 	return t
 }
 
+// Sort recursively sorts the node's children in place.
+//
+// Sort returns the original node for chaining.
 func (t *Tree) Sort(opts ...SortOption) *Tree {
 	options := newSortOptions(opts...)
 	sort.SliceStable(t.children, func(i, j int) bool {
@@ -80,10 +113,12 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 	return t
 }
 
+// String returns the tree's visual representation.
 func (t *Tree) String() string {
 	return t.Title() + t.printChildren("")
 }
 
+// Title returns the node's title.
 func (t *Tree) Title() string {
 	return t.title
 }
@@ -106,5 +141,5 @@ func (t *Tree) printChildren(prefix string) string {
 	return out
 }
 
-// Verify that tree implements fmt.Stringer
+// Verify that tree implements fmt.Stringer:
 var _ fmt.Stringer = (*Tree)(nil)

--- a/asciitree.go
+++ b/asciitree.go
@@ -18,7 +18,7 @@ func New(title string) *Tree {
 	return &Tree{title: title}
 }
 
-// New creates a tree node and forces it to be recognized as a branch.
+// NewBranch creates a tree node and forces it to be recognized as a branch.
 func NewBranch(title string) *Tree {
 	return &Tree{forceBranch: true, title: title}
 }
@@ -35,10 +35,10 @@ func (t *Tree) Add(titles ...string) *Tree {
 	return t
 }
 
-// AddBranch creates one or more tree nodes with the provided titles, forces
+// AddBranches creates one or more tree nodes with the provided titles, forces
 // them to be recognized as branches, and appends them to the node's children.
 //
-// Unlike NewChildBranch, AddBranch returns the original node for chaining.
+// Unlike NewChildBranch, AddBranches returns the original node for chaining.
 func (t *Tree) AddBranches(titles ...string) *Tree {
 	for _, title := range titles {
 		child := NewBranch(title)
@@ -79,7 +79,7 @@ func (t *Tree) NewChild(title string) *Tree {
 // NewChildBranch creates a tree node, forces it to be recognized as a branch,
 // and appends it to the node's children.
 //
-// Unlike AddBranch, NewChildBranch returns the newly created node.
+// Unlike AddBranches, NewChildBranch returns the newly created node.
 func (t *Tree) NewChildBranch(title string) *Tree {
 	child := NewBranch(title)
 	t.children = append(t.children, child)

--- a/asciitree.go
+++ b/asciitree.go
@@ -103,7 +103,7 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 	sort.SliceStable(t.children, func(i, j int) bool {
 		a := t.children[i]
 		b := t.children[j]
-		if options.dirsFirst && a.IsBranch() && !b.IsBranch() {
+		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
 			return true
 		}
 		return a.Title() < b.Title()

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -263,7 +263,7 @@ func TestTreeSort(t *testing.T) {
 		}},
 	}, {
 		name: "directories before files",
-		give: []SortOption{WithDirsFirst(true)},
+		give: []SortOption{WithBranchesFirst(true)},
 		want: &Tree{title: "alfa", children: []*Tree{
 			{title: "bravo", children: []*Tree{
 				{title: "foxtrot", children: []*Tree{

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -10,10 +10,10 @@ import (
 func TestNew(t *testing.T) {
 	tests := []struct {
 		give string
-		want Tree
+		want *Tree
 	}{
-		{"alfa", &tree{title: "alfa"}},
-		{"bravo", &tree{title: "bravo"}},
+		{"alfa", &Tree{title: "alfa"}},
+		{"bravo", &Tree{title: "bravo"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -26,10 +26,10 @@ func TestNew(t *testing.T) {
 func TestNewBranch(t *testing.T) {
 	tests := []struct {
 		give string
-		want Tree
+		want *Tree
 	}{
-		{"alfa", &tree{title: "alfa", forceBranch: true}},
-		{"bravo", &tree{title: "bravo", forceBranch: true}},
+		{"alfa", &Tree{title: "alfa", forceBranch: true}},
+		{"bravo", &Tree{title: "bravo", forceBranch: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -42,25 +42,25 @@ func TestNewBranch(t *testing.T) {
 func TestTreeAdd(t *testing.T) {
 	tests := []struct {
 		name string
-		tree Tree
+		tree *Tree
 		give []string
-		want Tree
+		want *Tree
 	}{{
 		name: "empty",
 		tree: New("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie"},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie"},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie"},
-			&tree{title: "delta"},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie"},
+			{title: "delta"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -74,25 +74,25 @@ func TestTreeAdd(t *testing.T) {
 func TestTreeAddBranches(t *testing.T) {
 	tests := []struct {
 		name string
-		tree Tree
+		tree *Tree
 		give []string
-		want Tree
+		want *Tree
 	}{{
 		name: "empty",
 		tree: New("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo", forceBranch: true},
-			&tree{title: "charlie", forceBranch: true},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo", forceBranch: true},
+			{title: "charlie", forceBranch: true},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie", forceBranch: true},
-			&tree{title: "delta", forceBranch: true},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie", forceBranch: true},
+			{title: "delta", forceBranch: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -106,25 +106,25 @@ func TestTreeAddBranches(t *testing.T) {
 func TestTreeAddTrees(t *testing.T) {
 	tests := []struct {
 		name string
-		tree Tree
-		give []Tree
-		want Tree
+		tree *Tree
+		give []*Tree
+		want *Tree
 	}{{
 		name: "empty",
 		tree: New("alfa"),
-		give: []Tree{New("bravo"), New("charlie")},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie"},
+		give: []*Tree{New("bravo"), New("charlie")},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie"},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
-		give: []Tree{New("charlie"), New("delta")},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie"},
-			&tree{title: "delta"},
+		give: []*Tree{New("charlie"), New("delta")},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie"},
+			{title: "delta"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -138,7 +138,7 @@ func TestTreeAddTrees(t *testing.T) {
 func TestTreeIsBranch(t *testing.T) {
 	tests := []struct {
 		name string
-		tree Tree
+		tree *Tree
 		want bool
 	}{
 		{"empty", New("alfa"), false},
@@ -156,27 +156,27 @@ func TestTreeIsBranch(t *testing.T) {
 func TestTreeNewChild(t *testing.T) {
 	tests := []struct {
 		name      string
-		tree      Tree
+		tree      *Tree
 		give      string
-		wantTree  Tree
-		wantChild Tree
+		wantTree  *Tree
+		wantChild *Tree
 	}{{
 		name: "empty",
 		tree: New("alfa"),
 		give: "bravo",
-		wantTree: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
+		wantTree: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
 		}},
-		wantChild: &tree{title: "bravo"},
+		wantChild: &Tree{title: "bravo"},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: "charlie",
-		wantTree: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie"},
+		wantTree: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie"},
 		}},
-		wantChild: &tree{title: "charlie"},
+		wantChild: &Tree{title: "charlie"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -190,27 +190,27 @@ func TestTreeNewChild(t *testing.T) {
 func TestTreeNewChildBranch(t *testing.T) {
 	tests := []struct {
 		name      string
-		tree      Tree
+		tree      *Tree
 		give      string
-		wantTree  Tree
-		wantChild Tree
+		wantTree  *Tree
+		wantChild *Tree
 	}{{
 		name: "empty",
 		tree: New("alfa"),
 		give: "bravo",
-		wantTree: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo", forceBranch: true},
+		wantTree: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo", forceBranch: true},
 		}},
-		wantChild: &tree{title: "bravo", forceBranch: true},
+		wantChild: &Tree{title: "bravo", forceBranch: true},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: "charlie",
-		wantTree: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo"},
-			&tree{title: "charlie", forceBranch: true},
+		wantTree: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo"},
+			{title: "charlie", forceBranch: true},
 		}},
-		wantChild: &tree{title: "charlie", forceBranch: true},
+		wantChild: &Tree{title: "charlie", forceBranch: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -223,12 +223,12 @@ func TestTreeNewChildBranch(t *testing.T) {
 
 func TestTreeSetTitle(t *testing.T) {
 	tests := []struct {
-		tree Tree
+		tree *Tree
 		give string
-		want Tree
+		want *Tree
 	}{
-		{New("alfa"), "bravo", &tree{title: "bravo"}},
-		{New("charlie"), "delta", &tree{title: "delta"}},
+		{New("alfa"), "bravo", &Tree{title: "bravo"}},
+		{New("charlie"), "delta", &Tree{title: "delta"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -242,42 +242,42 @@ func TestTreeSort(t *testing.T) {
 	tests := []struct {
 		name string
 		give []SortOption
-		want Tree
+		want *Tree
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo", children: []Tree{
-				&tree{title: "foxtrot", children: []Tree{
-					&tree{title: "india.txt"},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo", children: []*Tree{
+				{title: "foxtrot", children: []*Tree{
+					{title: "india.txt"},
 				}},
-				&tree{title: "golf.txt"},
-				&tree{title: "hotel", forceBranch: true},
+				{title: "golf.txt"},
+				{title: "hotel", forceBranch: true},
 			}},
-			&tree{title: "charlie.txt"},
-			&tree{title: "delta", forceBranch: true},
-			&tree{title: "echo.txt"},
-			&tree{title: "kilo", children: []Tree{
-				&tree{title: "juliet.txt"},
+			{title: "charlie.txt"},
+			{title: "delta", forceBranch: true},
+			{title: "echo.txt"},
+			{title: "kilo", children: []*Tree{
+				{title: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithDirsFirst(true)},
-		want: &tree{title: "alfa", children: []Tree{
-			&tree{title: "bravo", children: []Tree{
-				&tree{title: "foxtrot", children: []Tree{
-					&tree{title: "india.txt"},
+		want: &Tree{title: "alfa", children: []*Tree{
+			{title: "bravo", children: []*Tree{
+				{title: "foxtrot", children: []*Tree{
+					{title: "india.txt"},
 				}},
-				&tree{title: "hotel", forceBranch: true},
-				&tree{title: "golf.txt"},
+				{title: "hotel", forceBranch: true},
+				{title: "golf.txt"},
 			}},
-			&tree{title: "delta", forceBranch: true},
-			&tree{title: "kilo", children: []Tree{
-				&tree{title: "juliet.txt"},
+			{title: "delta", forceBranch: true},
+			{title: "kilo", children: []*Tree{
+				{title: "juliet.txt"},
 			}},
-			&tree{title: "charlie.txt"},
-			&tree{title: "echo.txt"},
+			{title: "charlie.txt"},
+			{title: "echo.txt"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -302,7 +302,7 @@ func TestTreeSort(t *testing.T) {
 func TestTreeString(t *testing.T) {
 	tests := []struct {
 		name string
-		tree Tree
+		tree *Tree
 		want string
 	}{{
 		name: "single node",
@@ -360,7 +360,7 @@ func TestTreeString(t *testing.T) {
 
 func TestTreeTitle(t *testing.T) {
 	tests := []struct {
-		tree Tree
+		tree *Tree
 		want string
 	}{
 		{New("alfa"), "alfa"},
@@ -374,4 +374,4 @@ func TestTreeTitle(t *testing.T) {
 	}
 }
 
-var cmpOptions = cmp.AllowUnexported(tree{})
+var cmpOptions = cmp.AllowUnexported(Tree{})

--- a/options.go
+++ b/options.go
@@ -1,29 +1,32 @@
 package asciitree
 
-type SortOptions struct {
-	branchesFirst bool
-}
-
+// SortOption represents an option that can be provided to the Sort method.
 type SortOption interface {
-	apply(*SortOptions)
+	apply(*sortOptions)
 }
 
-func WithBranchesFirst(value bool) SortOption {
-	return branchesFirstOption(value)
+type sortOptions struct {
+	branchesFirst bool
 }
 
 type branchesFirstOption bool
 
-func newSortOptions(opts ...SortOption) SortOptions {
-	var options SortOptions
+// WithBranchesFirst is an option that makes the Sort method order branches
+// before leaves.
+func WithBranchesFirst(value bool) SortOption {
+	return branchesFirstOption(value)
+}
+
+func (d branchesFirstOption) apply(opts *sortOptions) {
+	opts.branchesFirst = bool(d)
+}
+
+func newSortOptions(opts ...SortOption) sortOptions {
+	var options sortOptions
 	for _, o := range opts {
 		o.apply(&options)
 	}
 	return options
-}
-
-func (d branchesFirstOption) apply(opts *SortOptions) {
-	opts.branchesFirst = bool(d)
 }
 
 // Verify that branchesFirstOption implements asciitree.SortOption

--- a/options.go
+++ b/options.go
@@ -1,18 +1,18 @@
 package asciitree
 
 type SortOptions struct {
-	dirsFirst bool
+	branchesFirst bool
 }
 
 type SortOption interface {
 	apply(*SortOptions)
 }
 
-func WithDirsFirst(value bool) SortOption {
-	return dirsFirstOption(value)
+func WithBranchesFirst(value bool) SortOption {
+	return branchesFirstOption(value)
 }
 
-type dirsFirstOption bool
+type branchesFirstOption bool
 
 func newSortOptions(opts ...SortOption) SortOptions {
 	var options SortOptions
@@ -22,9 +22,9 @@ func newSortOptions(opts ...SortOption) SortOptions {
 	return options
 }
 
-func (d dirsFirstOption) apply(opts *SortOptions) {
-	opts.dirsFirst = bool(d)
+func (d branchesFirstOption) apply(opts *SortOptions) {
+	opts.branchesFirst = bool(d)
 }
 
-// Verify that dirsFirstOption implements asciitree.SortOption
-var _ SortOption = (*dirsFirstOption)(nil)
+// Verify that branchesFirstOption implements asciitree.SortOption
+var _ SortOption = (*branchesFirstOption)(nil)


### PR DESCRIPTION
This PR:

- Sets up a workflow to generate `README.md` based on `go doc` using `goreadme`.
- Adds essential documentation to all exported entities.

Apart from that:
- Merges the `Tree` interface and the `tree` struct into a single entity.
- Renames `WithDirsFirst` to `WithBranchesFirst`.
- Fine-tunes the visibility of entities.
- Renames the testing workflow to `test`.