### PR TITLE
Simplify API

### DIFF
--- a/asciitree.go
+++ b/asciitree.go
@@ -9,96 +9,28 @@ import (
 
 // Tree represents a tree node.
 type Tree struct {
-	children    []*Tree
-	forceBranch bool
-	title       string
-}
-
-// New creates a tree node.
-func New(title string) *Tree {
-	return &Tree{title: title}
-}
-
-// NewBranch creates a tree node and forces it to be recognized as a branch.
-func NewBranch(title string) *Tree {
-	return &Tree{forceBranch: true, title: title}
+	// Children is the slice of the node's children.
+	Children []*Tree
+	// ForceBranch reports whether the node should be forced to be recognized as a
+	// branch.
+	ForceBranch bool
+	// Title is the title of the node.
+	Title string
 }
 
 // Sprint returns the tree's visual representation.
 func Sprint(t *Tree) string {
-	return t.Title() + t.printChildren("")
-}
-
-// Add creates one or more tree nodes with the provided titles and appends them
-// to the node's children.
-//
-// Unlike NewChild, Add returns the original node for chaining.
-func (t *Tree) Add(titles ...string) *Tree {
-	for _, title := range titles {
-		child := New(title)
-		t.children = append(t.children, child)
-	}
-	return t
-}
-
-// AddBranches creates one or more tree nodes with the provided titles, forces
-// them to be recognized as branches, and appends them to the node's children.
-//
-// Unlike NewChildBranch, AddBranches returns the original node for chaining.
-func (t *Tree) AddBranches(titles ...string) *Tree {
-	for _, title := range titles {
-		child := NewBranch(title)
-		t.children = append(t.children, child)
-	}
-	return t
-}
-
-// AddTrees appends the provided tree nodes to the node's children.
-//
-// Unlike NewChild and NewChildBranch, AddTrees returns the original node for
-// chaining.
-func (t *Tree) AddTrees(trees ...*Tree) *Tree {
-	for _, tree := range trees {
-		t.children = append(t.children, tree)
-	}
-	return t
+	return t.Title + t.printChildren("")
 }
 
 // IsBranch reports whether the node should be recognized as a branch. This is
 // possible in two cases:
 //
 // - The node has one or more children.
-// - The node was forced to be recognized as a branch by creating it with the
-// NewBranch function or the NewChildBranch method.
+// - The node was forced to be recognized as a branch by setting its ForceBranch
+// field to true.
 func (t *Tree) IsBranch() bool {
-	return t.forceBranch || len(t.children) > 0
-}
-
-// NewChild creates a tree node and appends it to the node's children.
-//
-// Unlike Add, NewChild returns the newly created node.
-func (t *Tree) NewChild(title string) *Tree {
-	child := New(title)
-	t.children = append(t.children, child)
-	return child
-}
-
-// NewChildBranch creates a tree node, forces it to be recognized as a branch,
-// and appends it to the node's children.
-//
-// Unlike AddBranches, NewChildBranch returns the newly created node.
-func (t *Tree) NewChildBranch(title string) *Tree {
-	child := NewBranch(title)
-	t.children = append(t.children, child)
-	return child
-}
-
-// SetTitle sets the node's title.
-//
-// SetTitle returns the original node for chaining.
-func (t *Tree) SetTitle(title string) *Tree {
-	t.title = title
-	return t
+	return t.ForceBranch || len(t.Children) > 0
 }
 
 // Sort recursively sorts the node's children in place.
@@ -106,38 +38,33 @@ func (t *Tree) SetTitle(title string) *Tree {
 // Sort returns the original node for chaining.
 func (t *Tree) Sort(opts ...SortOption) *Tree {
 	options := newSortOptions(opts...)
-	sort.SliceStable(t.children, func(i, j int) bool {
-		a := t.children[i]
-		b := t.children[j]
+	sort.SliceStable(t.Children, func(i, j int) bool {
+		a := t.Children[i]
+		b := t.Children[j]
 		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
 			return true
 		}
-		return a.Title() < b.Title()
+		return a.Title < b.Title
 	})
-	for _, child := range t.children {
+	for _, child := range t.Children {
 		child.Sort(opts...)
 	}
 	return t
 }
 
-// Title returns the node's title.
-func (t *Tree) Title() string {
-	return t.title
-}
-
 func (t *Tree) printChildren(prefix string) string {
 	var out string
-	for i, child := range t.children {
+	for i, child := range t.Children {
 		connector := "├── "
 		spacer := "│   "
-		if i == len(t.children)-1 {
+		if i == len(t.Children)-1 {
 			connector = "└── "
 			spacer = "    "
 		}
 		out += "\n" +
 			prefix +
 			connector +
-			strings.ReplaceAll(child.Title(), "\n", "\n"+spacer) +
+			strings.ReplaceAll(child.Title, "\n", "\n"+spacer) +
 			child.printChildren(prefix+spacer)
 	}
 	return out

--- a/asciitree.go
+++ b/asciitree.go
@@ -21,8 +21,8 @@ type Node struct {
 // Sprint returns the node's visual representation.
 func Sprint(t *Node, opts ...SprintOption) string {
 	options := newSprintOptions(opts...)
-	sortChildren(t, options)
-	return t.Title + t.printChildren("")
+	sorted := sortChildren(t, options)
+	return sorted.Title + sorted.printChildren("")
 }
 
 func (t *Node) isBranch() bool {
@@ -48,9 +48,11 @@ func (t *Node) printChildren(prefix string) string {
 }
 
 func sortChildren(t *Node, options sprintOptions) *Node {
-	sort.SliceStable(t.Children, func(i, j int) bool {
-		a := t.Children[i]
-		b := t.Children[j]
+	copy := *t
+	copy.Children = append([]*Node(nil), copy.Children...)
+	sort.SliceStable(copy.Children, func(i, j int) bool {
+		a := copy.Children[i]
+		b := copy.Children[j]
 		if options.branchesFirst && a.isBranch() && !b.isBranch() {
 			return true
 		}
@@ -59,8 +61,8 @@ func sortChildren(t *Node, options sprintOptions) *Node {
 		}
 		return false
 	})
-	for _, child := range t.Children {
-		sortChildren(child, options)
+	for i, child := range copy.Children {
+		copy.Children[i] = sortChildren(child, options)
 	}
-	return t
+	return &copy
 }

--- a/asciitree.go
+++ b/asciitree.go
@@ -19,7 +19,9 @@ type Tree struct {
 }
 
 // Sprint returns the tree's visual representation.
-func Sprint(t *Tree) string {
+func Sprint(t *Tree, opts ...SprintOption) string {
+	options := newSprintOptions(opts...)
+	sortChildren(t, options)
 	return t.Title + t.printChildren("")
 }
 
@@ -31,25 +33,6 @@ func Sprint(t *Tree) string {
 // field to true.
 func (t *Tree) IsBranch() bool {
 	return t.ForceBranch || len(t.Children) > 0
-}
-
-// Sort recursively sorts the node's children in place.
-//
-// Sort returns the original node for chaining.
-func (t *Tree) Sort(opts ...SortOption) *Tree {
-	options := newSortOptions(opts...)
-	sort.SliceStable(t.Children, func(i, j int) bool {
-		a := t.Children[i]
-		b := t.Children[j]
-		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
-			return true
-		}
-		return a.Title < b.Title
-	})
-	for _, child := range t.Children {
-		child.Sort(opts...)
-	}
-	return t
 }
 
 func (t *Tree) printChildren(prefix string) string {
@@ -68,4 +51,19 @@ func (t *Tree) printChildren(prefix string) string {
 			child.printChildren(prefix+spacer)
 	}
 	return out
+}
+
+func sortChildren(t *Tree, options sprintOptions) *Tree {
+	sort.SliceStable(t.Children, func(i, j int) bool {
+		a := t.Children[i]
+		b := t.Children[j]
+		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
+			return true
+		}
+		return a.Title < b.Title
+	})
+	for _, child := range t.Children {
+		sortChildren(child, options)
+	}
+	return t
 }

--- a/asciitree.go
+++ b/asciitree.go
@@ -25,13 +25,7 @@ func Sprint(t *Tree, opts ...SprintOption) string {
 	return t.Title + t.printChildren("")
 }
 
-// IsBranch reports whether the node should be recognized as a branch. This is
-// possible in two cases:
-//
-// - The node has one or more children.
-// - The node was forced to be recognized as a branch by setting its ForceBranch
-// field to true.
-func (t *Tree) IsBranch() bool {
+func (t *Tree) isBranch() bool {
 	return t.ForceBranch || len(t.Children) > 0
 }
 
@@ -57,7 +51,7 @@ func sortChildren(t *Tree, options sprintOptions) *Tree {
 	sort.SliceStable(t.Children, func(i, j int) bool {
 		a := t.Children[i]
 		b := t.Children[j]
-		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
+		if options.branchesFirst && a.isBranch() && !b.isBranch() {
 			return true
 		}
 		return a.Title < b.Title

--- a/asciitree.go
+++ b/asciitree.go
@@ -3,7 +3,6 @@
 package asciitree
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
@@ -23,6 +22,11 @@ func New(title string) *Tree {
 // NewBranch creates a tree node and forces it to be recognized as a branch.
 func NewBranch(title string) *Tree {
 	return &Tree{forceBranch: true, title: title}
+}
+
+// Sprint returns the tree's visual representation.
+func Sprint(t *Tree) string {
+	return t.Title() + t.printChildren("")
 }
 
 // Add creates one or more tree nodes with the provided titles and appends them
@@ -116,11 +120,6 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 	return t
 }
 
-// String returns the tree's visual representation.
-func (t *Tree) String() string {
-	return t.Title() + t.printChildren("")
-}
-
 // Title returns the node's title.
 func (t *Tree) Title() string {
 	return t.title
@@ -143,6 +142,3 @@ func (t *Tree) printChildren(prefix string) string {
 	}
 	return out
 }
-
-// Verify that Tree implements fmt.Stringer:
-var _ fmt.Stringer = (*Tree)(nil)

--- a/asciitree.go
+++ b/asciitree.go
@@ -9,13 +9,13 @@ import (
 
 // Node represents a tree node.
 type Node struct {
-	// Children is the slice of the node's children.
-	Children []*Node
+	// Title is the title of the node.
+	Title string
 	// ForceBranch reports whether the node should be forced to be recognized as a
 	// branch.
 	ForceBranch bool
-	// Title is the title of the node.
-	Title string
+	// Children is the slice of the node's children.
+	Children []*Node
 }
 
 // Sprint returns the node's visual representation.

--- a/asciitree.go
+++ b/asciitree.go
@@ -19,22 +19,22 @@ type Node struct {
 }
 
 // Sprint returns the node's visual representation.
-func Sprint(t *Node, opts ...SprintOption) string {
+func Sprint(node *Node, opts ...SprintOption) string {
 	options := newSprintOptions(opts...)
-	sorted := sortChildren(t, options)
-	return sorted.Title + sorted.printChildren("")
+	sorted := sortChildren(node, options)
+	return sorted.Title + printChildren(sorted, "")
 }
 
-func (t *Node) isBranch() bool {
-	return t.ForceBranch || len(t.Children) > 0
+func isBranch(node *Node) bool {
+	return node.ForceBranch || len(node.Children) > 0
 }
 
-func (t *Node) printChildren(prefix string) string {
+func printChildren(node *Node, prefix string) string {
 	var out string
-	for i, child := range t.Children {
+	for i, child := range node.Children {
 		connector := "├── "
 		spacer := "│   "
-		if i == len(t.Children)-1 {
+		if i == len(node.Children)-1 {
 			connector = "└── "
 			spacer = "    "
 		}
@@ -42,18 +42,18 @@ func (t *Node) printChildren(prefix string) string {
 			prefix +
 			connector +
 			strings.ReplaceAll(child.Title, "\n", "\n"+spacer) +
-			child.printChildren(prefix+spacer)
+			printChildren(child, prefix+spacer)
 	}
 	return out
 }
 
-func sortChildren(t *Node, options sprintOptions) *Node {
-	copy := *t
+func sortChildren(node *Node, options sprintOptions) *Node {
+	copy := *node
 	copy.Children = append([]*Node(nil), copy.Children...)
 	sort.SliceStable(copy.Children, func(i, j int) bool {
 		a := copy.Children[i]
 		b := copy.Children[j]
-		if options.branchesFirst && a.isBranch() && !b.isBranch() {
+		if options.branchesFirst && isBranch(a) && !isBranch(b) {
 			return true
 		}
 		if options.sortByTitle {

--- a/asciitree.go
+++ b/asciitree.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 )
 
-// Tree represents a tree node.
-type Tree struct {
+// Node represents a tree node.
+type Node struct {
 	// Children is the slice of the node's children.
-	Children []*Tree
+	Children []*Node
 	// ForceBranch reports whether the node should be forced to be recognized as a
 	// branch.
 	ForceBranch bool
@@ -18,18 +18,18 @@ type Tree struct {
 	Title string
 }
 
-// Sprint returns the tree's visual representation.
-func Sprint(t *Tree, opts ...SprintOption) string {
+// Sprint returns the node's visual representation.
+func Sprint(t *Node, opts ...SprintOption) string {
 	options := newSprintOptions(opts...)
 	sortChildren(t, options)
 	return t.Title + t.printChildren("")
 }
 
-func (t *Tree) isBranch() bool {
+func (t *Node) isBranch() bool {
 	return t.ForceBranch || len(t.Children) > 0
 }
 
-func (t *Tree) printChildren(prefix string) string {
+func (t *Node) printChildren(prefix string) string {
 	var out string
 	for i, child := range t.Children {
 		connector := "├── "
@@ -47,7 +47,7 @@ func (t *Tree) printChildren(prefix string) string {
 	return out
 }
 
-func sortChildren(t *Tree, options sprintOptions) *Tree {
+func sortChildren(t *Node, options sprintOptions) *Node {
 	sort.SliceStable(t.Children, func(i, j int) bool {
 		a := t.Children[i]
 		b := t.Children[j]

--- a/asciitree.go
+++ b/asciitree.go
@@ -54,7 +54,10 @@ func sortChildren(t *Tree, options sprintOptions) *Tree {
 		if options.branchesFirst && a.isBranch() && !b.isBranch() {
 			return true
 		}
-		return a.Title < b.Title
+		if options.sortByTitle {
+			return a.Title < b.Title
+		}
+		return false
 	})
 	for _, child := range t.Children {
 		sortChildren(child, options)

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -76,8 +76,36 @@ func TestSprint_options(t *testing.T) {
 		give []SprintOption
 		want string
 	}{{
-		name: "default",
+		name: "none",
 		give: []SprintOption{},
+		want: `alfa
+├── charlie.txt
+├── bravo
+│   ├── golf.txt
+│   ├── foxtrot
+│   │   └── india.txt
+│   └── hotel
+├── kilo
+│   └── juliet.txt
+├── delta
+└── echo.txt`,
+	}, {
+		name: "branches first",
+		give: []SprintOption{WithBranchesFirst(true)},
+		want: `alfa
+├── bravo
+│   ├── foxtrot
+│   │   └── india.txt
+│   ├── hotel
+│   └── golf.txt
+├── kilo
+│   └── juliet.txt
+├── delta
+├── charlie.txt
+└── echo.txt`,
+	}, {
+		name: "sort by title",
+		give: []SprintOption{WithSortByTitle(true)},
 		want: `alfa
 ├── bravo
 │   ├── foxtrot
@@ -90,8 +118,8 @@ func TestSprint_options(t *testing.T) {
 └── kilo
     └── juliet.txt`,
 	}, {
-		name: "directories before files",
-		give: []SprintOption{WithBranchesFirst(true)},
+		name: "branches first + sort by title",
+		give: []SprintOption{WithBranchesFirst(true), WithSortByTitle(true)},
 		want: `alfa
 ├── bravo
 │   ├── foxtrot

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -39,6 +39,65 @@ func TestNewBranch(t *testing.T) {
 	}
 }
 
+func TestSprint(t *testing.T) {
+	tests := []struct {
+		name string
+		tree *Tree
+		want string
+	}{{
+		name: "single node",
+		tree: New("alfa"),
+		want: `alfa`,
+	}, {
+		name: "branched nodes",
+		tree: New("alfa").AddTrees(
+			New("bravo.txt"),
+			New("charlie").AddTrees(
+				New("delta.txt"),
+				New("echo").Add("foxtrot.txt", "golf.txt"),
+			),
+		),
+		want: `alfa
+├── bravo.txt
+└── charlie
+    ├── delta.txt
+    └── echo
+        ├── foxtrot.txt
+        └── golf.txt`,
+	}, {
+		name: "intersected branched nodes",
+		tree: New("alfa").AddTrees(
+			New("bravo").Add("charlie.txt"),
+			New("delta.txt"),
+		),
+		want: `alfa
+├── bravo
+│   └── charlie.txt
+└── delta.txt`,
+	}, {
+		name: "multiline titles",
+		tree: New("alfa\n[dir]\n[3 MB]").Add(
+			"bravo.txt\n[file]\n[1 MB]",
+			"charlie.txt\n[file]\n[2 MB]",
+		),
+		want: `alfa
+[dir]
+[3 MB]
+├── bravo.txt
+│   [file]
+│   [1 MB]
+└── charlie.txt
+    [file]
+    [2 MB]`,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sprint(tt.tree)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
 func TestTreeAdd(t *testing.T) {
 	tests := []struct {
 		name string
@@ -295,65 +354,6 @@ func TestTreeSort(t *testing.T) {
 			)
 			got := tree.Sort(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeString(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		want string
-	}{{
-		name: "single node",
-		tree: New("alfa"),
-		want: `alfa`,
-	}, {
-		name: "branched nodes",
-		tree: New("alfa").AddTrees(
-			New("bravo.txt"),
-			New("charlie").AddTrees(
-				New("delta.txt"),
-				New("echo").Add("foxtrot.txt", "golf.txt"),
-			),
-		),
-		want: `alfa
-├── bravo.txt
-└── charlie
-    ├── delta.txt
-    └── echo
-        ├── foxtrot.txt
-        └── golf.txt`,
-	}, {
-		name: "intersected branched nodes",
-		tree: New("alfa").AddTrees(
-			New("bravo").Add("charlie.txt"),
-			New("delta.txt"),
-		),
-		want: `alfa
-├── bravo
-│   └── charlie.txt
-└── delta.txt`,
-	}, {
-		name: "multiline titles",
-		tree: New("alfa\n[dir]\n[3 MB]").Add(
-			"bravo.txt\n[file]\n[1 MB]",
-			"charlie.txt\n[file]\n[2 MB]",
-		),
-		want: `alfa
-[dir]
-[3 MB]
-├── bravo.txt
-│   [file]
-│   [1 MB]
-└── charlie.txt
-    [file]
-    [2 MB]`,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.String()
-			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -7,38 +7,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestNew(t *testing.T) {
-	tests := []struct {
-		give string
-		want *Tree
-	}{
-		{"alfa", &Tree{title: "alfa"}},
-		{"bravo", &Tree{title: "bravo"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			got := New(tt.give)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestNewBranch(t *testing.T) {
-	tests := []struct {
-		give string
-		want *Tree
-	}{
-		{"alfa", &Tree{title: "alfa", forceBranch: true}},
-		{"bravo", &Tree{title: "bravo", forceBranch: true}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			got := NewBranch(tt.give)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
 func TestSprint(t *testing.T) {
 	tests := []struct {
 		name string
@@ -46,17 +14,20 @@ func TestSprint(t *testing.T) {
 		want string
 	}{{
 		name: "single node",
-		tree: New("alfa"),
+		tree: &Tree{Title: "alfa"},
 		want: `alfa`,
 	}, {
 		name: "branched nodes",
-		tree: New("alfa").AddTrees(
-			New("bravo.txt"),
-			New("charlie").AddTrees(
-				New("delta.txt"),
-				New("echo").Add("foxtrot.txt", "golf.txt"),
-			),
-		),
+		tree: &Tree{Title: "alfa", Children: []*Tree{
+			{Title: "bravo.txt"},
+			{Title: "charlie", Children: []*Tree{
+				{Title: "delta.txt"},
+				{Title: "echo", Children: []*Tree{
+					{Title: "foxtrot.txt"},
+					{Title: "golf.txt"},
+				}},
+			}},
+		}},
 		want: `alfa
 ├── bravo.txt
 └── charlie
@@ -66,20 +37,22 @@ func TestSprint(t *testing.T) {
         └── golf.txt`,
 	}, {
 		name: "intersected branched nodes",
-		tree: New("alfa").AddTrees(
-			New("bravo").Add("charlie.txt"),
-			New("delta.txt"),
-		),
+		tree: &Tree{Title: "alfa", Children: []*Tree{
+			{Title: "bravo", Children: []*Tree{
+				{Title: "charlie.txt"},
+			}},
+			{Title: "delta.txt"},
+		}},
 		want: `alfa
 ├── bravo
 │   └── charlie.txt
 └── delta.txt`,
 	}, {
 		name: "multiline titles",
-		tree: New("alfa\n[dir]\n[3 MB]").Add(
-			"bravo.txt\n[file]\n[1 MB]",
-			"charlie.txt\n[file]\n[2 MB]",
-		),
+		tree: &Tree{Title: "alfa\n[dir]\n[3 MB]", Children: []*Tree{
+			{Title: "bravo.txt\n[file]\n[1 MB]"},
+			{Title: "charlie.txt\n[file]\n[2 MB]"},
+		}},
 		want: `alfa
 [dir]
 [3 MB]
@@ -98,201 +71,30 @@ func TestSprint(t *testing.T) {
 	}
 }
 
-func TestTreeAdd(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		give []string
-		want *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: []string{"bravo", "charlie"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-		}},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: []string{"charlie", "delta"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-			{title: "delta"},
-		}},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.Add(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeAddBranches(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		give []string
-		want *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: []string{"bravo", "charlie"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", forceBranch: true},
-			{title: "charlie", forceBranch: true},
-		}},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: []string{"charlie", "delta"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie", forceBranch: true},
-			{title: "delta", forceBranch: true},
-		}},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.AddBranches(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeAddTrees(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		give []*Tree
-		want *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: []*Tree{New("bravo"), New("charlie")},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-		}},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: []*Tree{New("charlie"), New("delta")},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-			{title: "delta"},
-		}},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.AddTrees(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
 func TestTreeIsBranch(t *testing.T) {
 	tests := []struct {
 		name string
 		tree *Tree
 		want bool
-	}{
-		{"empty", New("alfa"), false},
-		{"has children", New("alfa").Add("bravo"), true},
-		{"forced", NewBranch("alfa"), true},
-	}
+	}{{
+		name: "empty",
+		tree: &Tree{Title: "alfa"},
+		want: false,
+	}, {
+		name: "has children",
+		tree: &Tree{Title: "alfa", Children: []*Tree{
+			{Title: "bravo"},
+		}},
+		want: true,
+	}, {
+		name: "forced",
+		tree: &Tree{Title: "alfa", ForceBranch: true},
+		want: true,
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.tree.IsBranch()
 			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func TestTreeNewChild(t *testing.T) {
-	tests := []struct {
-		name      string
-		tree      *Tree
-		give      string
-		wantTree  *Tree
-		wantChild *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: "bravo",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-		}},
-		wantChild: &Tree{title: "bravo"},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: "charlie",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-		}},
-		wantChild: &Tree{title: "charlie"},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChild(tt.give)
-			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
-			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
-		})
-	}
-}
-
-func TestTreeNewChildBranch(t *testing.T) {
-	tests := []struct {
-		name      string
-		tree      *Tree
-		give      string
-		wantTree  *Tree
-		wantChild *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: "bravo",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", forceBranch: true},
-		}},
-		wantChild: &Tree{title: "bravo", forceBranch: true},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: "charlie",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie", forceBranch: true},
-		}},
-		wantChild: &Tree{title: "charlie", forceBranch: true},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChildBranch(tt.give)
-			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
-			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
-		})
-	}
-}
-
-func TestTreeSetTitle(t *testing.T) {
-	tests := []struct {
-		tree *Tree
-		give string
-		want *Tree
-	}{
-		{New("alfa"), "bravo", &Tree{title: "bravo"}},
-		{New("charlie"), "delta", &Tree{title: "delta"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			got := tt.tree.SetTitle(tt.give)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
 }
@@ -305,71 +107,59 @@ func TestTreeSort(t *testing.T) {
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", children: []*Tree{
-				{title: "foxtrot", children: []*Tree{
-					{title: "india.txt"},
+		want: &Tree{Title: "alfa", Children: []*Tree{
+			{Title: "bravo", Children: []*Tree{
+				{Title: "foxtrot", Children: []*Tree{
+					{Title: "india.txt"},
 				}},
-				{title: "golf.txt"},
-				{title: "hotel", forceBranch: true},
+				{Title: "golf.txt"},
+				{Title: "hotel", ForceBranch: true},
 			}},
-			{title: "charlie.txt"},
-			{title: "delta", forceBranch: true},
-			{title: "echo.txt"},
-			{title: "kilo", children: []*Tree{
-				{title: "juliet.txt"},
+			{Title: "charlie.txt"},
+			{Title: "delta", ForceBranch: true},
+			{Title: "echo.txt"},
+			{Title: "kilo", Children: []*Tree{
+				{Title: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithBranchesFirst(true)},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", children: []*Tree{
-				{title: "foxtrot", children: []*Tree{
-					{title: "india.txt"},
+		want: &Tree{Title: "alfa", Children: []*Tree{
+			{Title: "bravo", Children: []*Tree{
+				{Title: "foxtrot", Children: []*Tree{
+					{Title: "india.txt"},
 				}},
-				{title: "hotel", forceBranch: true},
-				{title: "golf.txt"},
+				{Title: "hotel", ForceBranch: true},
+				{Title: "golf.txt"},
 			}},
-			{title: "delta", forceBranch: true},
-			{title: "kilo", children: []*Tree{
-				{title: "juliet.txt"},
+			{Title: "delta", ForceBranch: true},
+			{Title: "kilo", Children: []*Tree{
+				{Title: "juliet.txt"},
 			}},
-			{title: "charlie.txt"},
-			{title: "echo.txt"},
+			{Title: "charlie.txt"},
+			{Title: "echo.txt"},
 		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := New("alfa").AddTrees(
-				New("charlie.txt"),
-				New("bravo").AddTrees(
-					New("golf.txt"),
-					New("foxtrot").Add("india.txt"),
-					NewBranch("hotel"),
-				),
-				New("kilo").Add("juliet.txt"),
-				NewBranch("delta"),
-				New("echo.txt"),
-			)
+			tree := &Tree{Title: "alfa", Children: []*Tree{
+				{Title: "charlie.txt"},
+				{Title: "bravo", Children: []*Tree{
+					{Title: "golf.txt"},
+					{Title: "foxtrot", Children: []*Tree{
+						{Title: "india.txt"},
+					}},
+					{Title: "hotel", ForceBranch: true},
+				}},
+				{Title: "kilo", Children: []*Tree{
+					{Title: "juliet.txt"},
+				}},
+				{Title: "delta", ForceBranch: true},
+				{Title: "echo.txt"},
+			}}
 			got := tree.Sort(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeTitle(t *testing.T) {
-	tests := []struct {
-		tree *Tree
-		want string
-	}{
-		{New("alfa"), "alfa"},
-		{New("bravo"), "bravo"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got := tt.tree.Title()
-			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -9,19 +9,19 @@ import (
 func TestSprint(t *testing.T) {
 	tests := []struct {
 		name string
-		tree *Tree
+		tree *Node
 		want string
 	}{{
 		name: "single node",
-		tree: &Tree{Title: "alfa"},
+		tree: &Node{Title: "alfa"},
 		want: `alfa`,
 	}, {
 		name: "branched nodes",
-		tree: &Tree{Title: "alfa", Children: []*Tree{
+		tree: &Node{Title: "alfa", Children: []*Node{
 			{Title: "bravo.txt"},
-			{Title: "charlie", Children: []*Tree{
+			{Title: "charlie", Children: []*Node{
 				{Title: "delta.txt"},
-				{Title: "echo", Children: []*Tree{
+				{Title: "echo", Children: []*Node{
 					{Title: "foxtrot.txt"},
 					{Title: "golf.txt"},
 				}},
@@ -36,8 +36,8 @@ func TestSprint(t *testing.T) {
         └── golf.txt`,
 	}, {
 		name: "intersected branched nodes",
-		tree: &Tree{Title: "alfa", Children: []*Tree{
-			{Title: "bravo", Children: []*Tree{
+		tree: &Node{Title: "alfa", Children: []*Node{
+			{Title: "bravo", Children: []*Node{
 				{Title: "charlie.txt"},
 			}},
 			{Title: "delta.txt"},
@@ -48,7 +48,7 @@ func TestSprint(t *testing.T) {
 └── delta.txt`,
 	}, {
 		name: "multiline titles",
-		tree: &Tree{Title: "alfa\n[dir]\n[3 MB]", Children: []*Tree{
+		tree: &Node{Title: "alfa\n[dir]\n[3 MB]", Children: []*Node{
 			{Title: "bravo.txt\n[file]\n[1 MB]"},
 			{Title: "charlie.txt\n[file]\n[2 MB]"},
 		}},
@@ -134,16 +134,16 @@ func TestSprint_options(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := &Tree{Title: "alfa", Children: []*Tree{
+			tree := &Node{Title: "alfa", Children: []*Node{
 				{Title: "charlie.txt"},
-				{Title: "bravo", Children: []*Tree{
+				{Title: "bravo", Children: []*Node{
 					{Title: "golf.txt"},
-					{Title: "foxtrot", Children: []*Tree{
+					{Title: "foxtrot", Children: []*Node{
 						{Title: "india.txt"},
 					}},
 					{Title: "hotel", ForceBranch: true},
 				}},
-				{Title: "kilo", Children: []*Tree{
+				{Title: "kilo", Children: []*Node{
 					{Title: "juliet.txt"},
 				}},
 				{Title: "delta", ForceBranch: true},

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -70,34 +70,6 @@ func TestSprint(t *testing.T) {
 	}
 }
 
-func TestTreeIsBranch(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		want bool
-	}{{
-		name: "empty",
-		tree: &Tree{Title: "alfa"},
-		want: false,
-	}, {
-		name: "has children",
-		tree: &Tree{Title: "alfa", Children: []*Tree{
-			{Title: "bravo"},
-		}},
-		want: true,
-	}, {
-		name: "forced",
-		tree: &Tree{Title: "alfa", ForceBranch: true},
-		want: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.IsBranch()
-			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
 func TestSprint_options(t *testing.T) {
 	tests := []struct {
 		name string

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -3,7 +3,6 @@ package asciitree
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
 
@@ -99,47 +98,39 @@ func TestTreeIsBranch(t *testing.T) {
 	}
 }
 
-func TestTreeSort(t *testing.T) {
+func TestSprint_options(t *testing.T) {
 	tests := []struct {
 		name string
-		give []SortOption
-		want *Tree
+		give []SprintOption
+		want string
 	}{{
 		name: "default",
-		give: []SortOption{},
-		want: &Tree{Title: "alfa", Children: []*Tree{
-			{Title: "bravo", Children: []*Tree{
-				{Title: "foxtrot", Children: []*Tree{
-					{Title: "india.txt"},
-				}},
-				{Title: "golf.txt"},
-				{Title: "hotel", ForceBranch: true},
-			}},
-			{Title: "charlie.txt"},
-			{Title: "delta", ForceBranch: true},
-			{Title: "echo.txt"},
-			{Title: "kilo", Children: []*Tree{
-				{Title: "juliet.txt"},
-			}},
-		}},
+		give: []SprintOption{},
+		want: `alfa
+├── bravo
+│   ├── foxtrot
+│   │   └── india.txt
+│   ├── golf.txt
+│   └── hotel
+├── charlie.txt
+├── delta
+├── echo.txt
+└── kilo
+    └── juliet.txt`,
 	}, {
 		name: "directories before files",
-		give: []SortOption{WithBranchesFirst(true)},
-		want: &Tree{Title: "alfa", Children: []*Tree{
-			{Title: "bravo", Children: []*Tree{
-				{Title: "foxtrot", Children: []*Tree{
-					{Title: "india.txt"},
-				}},
-				{Title: "hotel", ForceBranch: true},
-				{Title: "golf.txt"},
-			}},
-			{Title: "delta", ForceBranch: true},
-			{Title: "kilo", Children: []*Tree{
-				{Title: "juliet.txt"},
-			}},
-			{Title: "charlie.txt"},
-			{Title: "echo.txt"},
-		}},
+		give: []SprintOption{WithBranchesFirst(true)},
+		want: `alfa
+├── bravo
+│   ├── foxtrot
+│   │   └── india.txt
+│   ├── hotel
+│   └── golf.txt
+├── delta
+├── kilo
+│   └── juliet.txt
+├── charlie.txt
+└── echo.txt`,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,10 +149,8 @@ func TestTreeSort(t *testing.T) {
 				{Title: "delta", ForceBranch: true},
 				{Title: "echo.txt"},
 			}}
-			got := tree.Sort(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
+			got := Sprint(tree, tt.give...)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }
-
-var cmpOptions = cmp.AllowUnexported(Tree{})

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -71,6 +71,24 @@ func TestSprint(t *testing.T) {
 }
 
 func TestSprint_options(t *testing.T) {
+	NewSample := func() *Node {
+		return &Node{Title: "alfa", Children: []*Node{
+			{Title: "charlie.txt"},
+			{Title: "bravo", Children: []*Node{
+				{Title: "golf.txt"},
+				{Title: "foxtrot", Children: []*Node{
+					{Title: "india.txt"},
+				}},
+				{Title: "hotel", ForceBranch: true},
+			}},
+			{Title: "kilo", Children: []*Node{
+				{Title: "juliet.txt"},
+			}},
+			{Title: "delta", ForceBranch: true},
+			{Title: "echo.txt"},
+		}}
+	}
+
 	tests := []struct {
 		name string
 		give []SprintOption
@@ -134,23 +152,10 @@ func TestSprint_options(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := &Node{Title: "alfa", Children: []*Node{
-				{Title: "charlie.txt"},
-				{Title: "bravo", Children: []*Node{
-					{Title: "golf.txt"},
-					{Title: "foxtrot", Children: []*Node{
-						{Title: "india.txt"},
-					}},
-					{Title: "hotel", ForceBranch: true},
-				}},
-				{Title: "kilo", Children: []*Node{
-					{Title: "juliet.txt"},
-				}},
-				{Title: "delta", ForceBranch: true},
-				{Title: "echo.txt"},
-			}}
+			tree := NewSample()
 			got := Sprint(tree, tt.give...)
 			assert.Equal(t, got, tt.want)
+			assert.DeepEqual(t, tree, NewSample())
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/borodean/asciitree
 
 go 1.16
 
-require (
-	github.com/google/go-cmp v0.5.6
-	gotest.tools/v3 v3.0.3
-)
+require gotest.tools/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/options.go
+++ b/options.go
@@ -1,6 +1,6 @@
 package asciitree
 
-// SprintOption represents an option that can be provided to the Sort method.
+// SprintOption represents an option that can be provided to the Sprint method.
 type SprintOption interface {
 	apply(*sprintOptions)
 }
@@ -11,7 +11,7 @@ type sprintOptions struct {
 
 type branchesFirstOption bool
 
-// WithBranchesFirst is an option that makes the Sort method order branches
+// WithBranchesFirst is an option that makes the Sprint method print branches
 // before leaves.
 func WithBranchesFirst(value bool) SprintOption {
 	return branchesFirstOption(value)

--- a/options.go
+++ b/options.go
@@ -12,7 +12,7 @@ type sprintOptions struct {
 
 type (
 	branchesFirstOption bool
-	sortByTitle         bool
+	sortByTitleOption   bool
 )
 
 // WithBranchesFirst is an option that makes the Sprint method print branches
@@ -24,14 +24,14 @@ func WithBranchesFirst(value bool) SprintOption {
 // WithSortByTitle is an option that makes the Sprint method print nodes in
 // an alphanumerical order.
 func WithSortByTitle(value bool) SprintOption {
-	return sortByTitle(value)
+	return sortByTitleOption(value)
 }
 
 func (d branchesFirstOption) apply(opts *sprintOptions) {
 	opts.branchesFirst = bool(d)
 }
 
-func (s sortByTitle) apply(opts *sprintOptions) {
+func (s sortByTitleOption) apply(opts *sprintOptions) {
 	opts.sortByTitle = bool(s)
 }
 
@@ -45,3 +45,4 @@ func newSprintOptions(opts ...SprintOption) sprintOptions {
 
 // Verify that branchesFirstOption implements asciitree.SprintOption
 var _ SprintOption = (*branchesFirstOption)(nil)
+var _ SprintOption = (*sortByTitleOption)(nil)

--- a/options.go
+++ b/options.go
@@ -1,11 +1,11 @@
 package asciitree
 
-// SortOption represents an option that can be provided to the Sort method.
-type SortOption interface {
-	apply(*sortOptions)
+// SprintOption represents an option that can be provided to the Sort method.
+type SprintOption interface {
+	apply(*sprintOptions)
 }
 
-type sortOptions struct {
+type sprintOptions struct {
 	branchesFirst bool
 }
 
@@ -13,21 +13,21 @@ type branchesFirstOption bool
 
 // WithBranchesFirst is an option that makes the Sort method order branches
 // before leaves.
-func WithBranchesFirst(value bool) SortOption {
+func WithBranchesFirst(value bool) SprintOption {
 	return branchesFirstOption(value)
 }
 
-func (d branchesFirstOption) apply(opts *sortOptions) {
+func (d branchesFirstOption) apply(opts *sprintOptions) {
 	opts.branchesFirst = bool(d)
 }
 
-func newSortOptions(opts ...SortOption) sortOptions {
-	var options sortOptions
+func newSprintOptions(opts ...SprintOption) sprintOptions {
+	var options sprintOptions
 	for _, o := range opts {
 		o.apply(&options)
 	}
 	return options
 }
 
-// Verify that branchesFirstOption implements asciitree.SortOption
-var _ SortOption = (*branchesFirstOption)(nil)
+// Verify that branchesFirstOption implements asciitree.SprintOption
+var _ SprintOption = (*branchesFirstOption)(nil)

--- a/options.go
+++ b/options.go
@@ -7,9 +7,13 @@ type SprintOption interface {
 
 type sprintOptions struct {
 	branchesFirst bool
+	sortByTitle   bool
 }
 
-type branchesFirstOption bool
+type (
+	branchesFirstOption bool
+	sortByTitle         bool
+)
 
 // WithBranchesFirst is an option that makes the Sprint method print branches
 // before leaves.
@@ -17,8 +21,18 @@ func WithBranchesFirst(value bool) SprintOption {
 	return branchesFirstOption(value)
 }
 
+// WithSortByTitle is an option that makes the Sprint method print nodes in
+// an alphanumerical order.
+func WithSortByTitle(value bool) SprintOption {
+	return sortByTitle(value)
+}
+
 func (d branchesFirstOption) apply(opts *sprintOptions) {
 	opts.branchesFirst = bool(d)
+}
+
+func (s sortByTitle) apply(opts *sprintOptions) {
+	opts.sortByTitle = bool(s)
 }
 
 func newSprintOptions(opts ...SprintOption) sprintOptions {


### PR DESCRIPTION
This PR simplifies the API, leaving only the `Node` struct, the `Sprint` function, and its options exported for the users.