### PR TITLE
Simplify API, second attempt

### DIFF
--- a/asciitree.go
+++ b/asciitree.go
@@ -10,9 +10,9 @@ import (
 
 // Tree represents a tree node.
 type Tree struct {
-	name        string
-	forceBranch bool
-	children    []*Tree
+	name     string
+	forceDir bool
+	children []*Tree
 }
 
 // New creates a tree node.
@@ -20,9 +20,9 @@ func New(name string) *Tree {
 	return &Tree{name: name}
 }
 
-// NewBranch creates a tree node and forces it to be recognized as a branch.
-func NewBranch(name string) *Tree {
-	return &Tree{forceBranch: true, name: name}
+// NewDir creates a tree node and forces it to be recognized as a directory.
+func NewDir(name string) *Tree {
+	return &Tree{forceDir: true, name: name}
 }
 
 // Add creates one or more tree nodes with the provided names and appends them
@@ -37,13 +37,13 @@ func (t *Tree) Add(names ...string) *Tree {
 	return t
 }
 
-// AddBranches creates one or more tree nodes with the provided names, forces
-// them to be recognized as branches, and appends them to the node's children.
+// AddDirs creates one or more tree nodes with the provided names, forces them
+// to be recognized as directories, and appends them to the node's children.
 //
-// Unlike NewChildBranch, AddBranches returns the original node for chaining.
-func (t *Tree) AddBranches(names ...string) *Tree {
+// Unlike NewChildDir, AddDirs returns the original node for chaining.
+func (t *Tree) AddDirs(names ...string) *Tree {
 	for _, name := range names {
-		child := NewBranch(name)
+		child := NewDir(name)
 		t.children = append(t.children, child)
 	}
 	return t
@@ -51,7 +51,7 @@ func (t *Tree) AddBranches(names ...string) *Tree {
 
 // AddTrees appends the provided tree nodes to the node's children.
 //
-// Unlike NewChild and NewChildBranch, AddTrees returns the original node for
+// Unlike NewChild and NewChildDir, AddTrees returns the original node for
 // chaining.
 func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	for _, tree := range trees {
@@ -60,14 +60,14 @@ func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	return t
 }
 
-// IsBranch reports whether the node should be recognized as a branch. This is
+// IsDir reports whether the node should be recognized as a directory. This is
 // possible in two cases:
 //
 // - The node has one or more children.
-// - The node was forced to be recognized as a branch by creating it with the
-// NewBranch function or the NewChildBranch method.
-func (t *Tree) IsBranch() bool {
-	return t.forceBranch || len(t.children) > 0
+// - The node was forced to be recognized as a directory by creating it with the
+// NewDir function or the NewChildDir method.
+func (t *Tree) IsDir() bool {
+	return t.forceDir || len(t.children) > 0
 }
 
 // NewChild creates a tree node and appends it to the node's children.
@@ -79,12 +79,12 @@ func (t *Tree) NewChild(name string) *Tree {
 	return child
 }
 
-// NewChildBranch creates a tree node, forces it to be recognized as a branch,
+// NewChildDir creates a tree node, forces it to be recognized as a directory,
 // and appends it to the node's children.
 //
-// Unlike AddBranches, NewChildBranch returns the newly created node.
-func (t *Tree) NewChildBranch(name string) *Tree {
-	child := NewBranch(name)
+// Unlike AddDirs, NewChildDir returns the newly created node.
+func (t *Tree) NewChildDir(name string) *Tree {
+	child := NewDir(name)
 	t.children = append(t.children, child)
 	return child
 }
@@ -105,7 +105,7 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 	sort.SliceStable(t.children, func(i, j int) bool {
 		a := t.children[i]
 		b := t.children[j]
-		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
+		if options.dirsFirst && a.IsDir() && !b.IsDir() {
 			return true
 		}
 		return a.Name() < b.Name()

--- a/asciitree.go
+++ b/asciitree.go
@@ -27,7 +27,7 @@ func NewFile(name string) *Tree {
 
 // Add appends the provided tree nodes to the node's children.
 //
-// Unlike NewChildFile and NewChildDir, Add returns the original node for
+// Unlike AddFile and AddDir, Add returns the original node for
 // chaining.
 func (t *Tree) Add(trees ...*Tree) *Tree {
 	for _, tree := range trees {
@@ -36,10 +36,20 @@ func (t *Tree) Add(trees ...*Tree) *Tree {
 	return t
 }
 
+// AddDir creates a tree node, forces it to be recognized as a directory,
+// and appends it to the node's children.
+//
+// Unlike AddDirs, AddDir returns the newly created node.
+func (t *Tree) AddDir(name string) *Tree {
+	child := NewDir(name)
+	t.children = append(t.children, child)
+	return child
+}
+
 // AddDirs creates one or more tree nodes with the provided names, forces them
 // to be recognized as directories, and appends them to the node's children.
 //
-// Unlike NewChildDir, AddDirs returns the original node for chaining.
+// Unlike AddDir, AddDirs returns the original node for chaining.
 func (t *Tree) AddDirs(names ...string) *Tree {
 	for _, name := range names {
 		child := NewDir(name)
@@ -48,10 +58,19 @@ func (t *Tree) AddDirs(names ...string) *Tree {
 	return t
 }
 
+// AddFile creates a tree node and appends it to the node's children.
+//
+// Unlike AddFiles, AddFile returns the newly created node.
+func (t *Tree) AddFile(name string) *Tree {
+	child := NewFile(name)
+	t.children = append(t.children, child)
+	return child
+}
+
 // AddFiles creates one or more tree nodes with the provided names and appends
 // them to the node's children.
 //
-// Unlike NewChildFile, AddFiles returns the original node for chaining.
+// Unlike AddFile, AddFiles returns the original node for chaining.
 func (t *Tree) AddFiles(names ...string) *Tree {
 	for _, name := range names {
 		child := NewFile(name)
@@ -63,25 +82,6 @@ func (t *Tree) AddFiles(names ...string) *Tree {
 // Name returns the node's name.
 func (t *Tree) Name() string {
 	return t.name
-}
-
-// NewChildDir creates a tree node, forces it to be recognized as a directory,
-// and appends it to the node's children.
-//
-// Unlike AddDirs, NewChildDir returns the newly created node.
-func (t *Tree) NewChildDir(name string) *Tree {
-	child := NewDir(name)
-	t.children = append(t.children, child)
-	return child
-}
-
-// NewChildFile creates a tree node and appends it to the node's children.
-//
-// Unlike AddFiles, NewChildFile returns the newly created node.
-func (t *Tree) NewChildFile(name string) *Tree {
-	child := NewFile(name)
-	t.children = append(t.children, child)
-	return child
 }
 
 // SetName sets the node's name.

--- a/asciitree.go
+++ b/asciitree.go
@@ -10,19 +10,22 @@ import (
 
 // Tree represents a tree node.
 type Tree struct {
-	name     string
-	isDir    bool
-	children []*Tree
+	// Name is the name of the node.
+	Name string
+	// IsDir identifies whether the node is a directory.
+	IsDir bool
+	// Children is the slice of the node's children.
+	Children []*Tree
 }
 
 // NewDir creates a tree node and forces it to be recognized as a directory.
 func NewDir(name string) *Tree {
-	return &Tree{isDir: true, name: name}
+	return &Tree{Name: name, IsDir: true}
 }
 
 // NewFile creates a tree node.
 func NewFile(name string) *Tree {
-	return &Tree{name: name}
+	return &Tree{Name: name}
 }
 
 // Add appends the provided tree nodes to the node's children.
@@ -31,7 +34,7 @@ func NewFile(name string) *Tree {
 // chaining.
 func (t *Tree) Add(trees ...*Tree) *Tree {
 	for _, tree := range trees {
-		t.children = append(t.children, tree)
+		t.Children = append(t.Children, tree)
 	}
 	return t
 }
@@ -42,7 +45,7 @@ func (t *Tree) Add(trees ...*Tree) *Tree {
 // Unlike AddDirs, AddDir returns the newly created node.
 func (t *Tree) AddDir(name string) *Tree {
 	child := NewDir(name)
-	t.children = append(t.children, child)
+	t.Children = append(t.Children, child)
 	return child
 }
 
@@ -53,7 +56,7 @@ func (t *Tree) AddDir(name string) *Tree {
 func (t *Tree) AddDirs(names ...string) *Tree {
 	for _, name := range names {
 		child := NewDir(name)
-		t.children = append(t.children, child)
+		t.Children = append(t.Children, child)
 	}
 	return t
 }
@@ -63,7 +66,7 @@ func (t *Tree) AddDirs(names ...string) *Tree {
 // Unlike AddFiles, AddFile returns the newly created node.
 func (t *Tree) AddFile(name string) *Tree {
 	child := NewFile(name)
-	t.children = append(t.children, child)
+	t.Children = append(t.Children, child)
 	return child
 }
 
@@ -74,21 +77,8 @@ func (t *Tree) AddFile(name string) *Tree {
 func (t *Tree) AddFiles(names ...string) *Tree {
 	for _, name := range names {
 		child := NewFile(name)
-		t.children = append(t.children, child)
+		t.Children = append(t.Children, child)
 	}
-	return t
-}
-
-// Name returns the node's name.
-func (t *Tree) Name() string {
-	return t.name
-}
-
-// SetName sets the node's name.
-//
-// SetName returns the original node for chaining.
-func (t *Tree) SetName(name string) *Tree {
-	t.name = name
 	return t
 }
 
@@ -97,15 +87,15 @@ func (t *Tree) SetName(name string) *Tree {
 // Sort returns the original node for chaining.
 func (t *Tree) Sort(opts ...SortOption) *Tree {
 	options := newSortOptions(opts...)
-	sort.SliceStable(t.children, func(i, j int) bool {
-		a := t.children[i]
-		b := t.children[j]
-		if options.dirsFirst && a.isDir && !b.isDir {
+	sort.SliceStable(t.Children, func(i, j int) bool {
+		a := t.Children[i]
+		b := t.Children[j]
+		if options.dirsFirst && a.IsDir && !b.IsDir {
 			return true
 		}
-		return a.Name() < b.Name()
+		return a.Name < b.Name
 	})
-	for _, child := range t.children {
+	for _, child := range t.Children {
 		child.Sort(opts...)
 	}
 	return t
@@ -113,22 +103,22 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 
 // String returns the tree's visual representation.
 func (t *Tree) String() string {
-	return t.Name() + t.printChildren("")
+	return t.Name + t.printChildren("")
 }
 
 func (t *Tree) printChildren(prefix string) string {
 	var out string
-	for i, child := range t.children {
+	for i, child := range t.Children {
 		connector := "├── "
 		spacer := "│   "
-		if i == len(t.children)-1 {
+		if i == len(t.Children)-1 {
 			connector = "└── "
 			spacer = "    "
 		}
 		out += "\n" +
 			prefix +
 			connector +
-			strings.ReplaceAll(child.Name(), "\n", "\n"+spacer) +
+			strings.ReplaceAll(child.Name, "\n", "\n"+spacer) +
 			child.printChildren(prefix+spacer)
 	}
 	return out

--- a/asciitree.go
+++ b/asciitree.go
@@ -15,26 +15,14 @@ type Tree struct {
 	children []*Tree
 }
 
-// New creates a tree node.
-func New(name string) *Tree {
-	return &Tree{name: name}
-}
-
 // NewDir creates a tree node and forces it to be recognized as a directory.
 func NewDir(name string) *Tree {
 	return &Tree{forceDir: true, name: name}
 }
 
-// Add creates one or more tree nodes with the provided names and appends them
-// to the node's children.
-//
-// Unlike NewChild, Add returns the original node for chaining.
-func (t *Tree) Add(names ...string) *Tree {
-	for _, name := range names {
-		child := New(name)
-		t.children = append(t.children, child)
-	}
-	return t
+// NewFile creates a tree node.
+func NewFile(name string) *Tree {
+	return &Tree{name: name}
 }
 
 // AddDirs creates one or more tree nodes with the provided names, forces them
@@ -49,9 +37,21 @@ func (t *Tree) AddDirs(names ...string) *Tree {
 	return t
 }
 
+// AddFile creates one or more tree nodes with the provided names and appends
+// them to the node's children.
+//
+// Unlike NewChildFile, AddFile returns the original node for chaining.
+func (t *Tree) AddFile(names ...string) *Tree {
+	for _, name := range names {
+		child := NewFile(name)
+		t.children = append(t.children, child)
+	}
+	return t
+}
+
 // AddTrees appends the provided tree nodes to the node's children.
 //
-// Unlike NewChild and NewChildDir, AddTrees returns the original node for
+// Unlike NewChildFile and NewChildDir, AddTrees returns the original node for
 // chaining.
 func (t *Tree) AddTrees(trees ...*Tree) *Tree {
 	for _, tree := range trees {
@@ -70,13 +70,9 @@ func (t *Tree) IsDir() bool {
 	return t.forceDir || len(t.children) > 0
 }
 
-// NewChild creates a tree node and appends it to the node's children.
-//
-// Unlike Add, NewChild returns the newly created node.
-func (t *Tree) NewChild(name string) *Tree {
-	child := New(name)
-	t.children = append(t.children, child)
-	return child
+// Name returns the node's name.
+func (t *Tree) Name() string {
+	return t.name
 }
 
 // NewChildDir creates a tree node, forces it to be recognized as a directory,
@@ -85,6 +81,15 @@ func (t *Tree) NewChild(name string) *Tree {
 // Unlike AddDirs, NewChildDir returns the newly created node.
 func (t *Tree) NewChildDir(name string) *Tree {
 	child := NewDir(name)
+	t.children = append(t.children, child)
+	return child
+}
+
+// NewChildFile creates a tree node and appends it to the node's children.
+//
+// Unlike AddFile, NewChildFile returns the newly created node.
+func (t *Tree) NewChildFile(name string) *Tree {
+	child := NewFile(name)
 	t.children = append(t.children, child)
 	return child
 }
@@ -119,11 +124,6 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 // String returns the tree's visual representation.
 func (t *Tree) String() string {
 	return t.Name() + t.printChildren("")
-}
-
-// Name returns the node's name.
-func (t *Tree) Name() string {
-	return t.name
 }
 
 func (t *Tree) printChildren(prefix string) string {

--- a/asciitree.go
+++ b/asciitree.go
@@ -8,32 +8,32 @@ import (
 	"strings"
 )
 
-// Tree represents a tree node.
-type Tree struct {
+// Node represents a tree node.
+type Node struct {
 	// Name is the name of the node.
 	Name string
 	// IsDir identifies whether the node is a directory.
 	IsDir bool
 	// Children is the slice of the node's children.
-	Children []*Tree
+	Children []*Node
 }
 
 // NewDir creates a tree node and forces it to be recognized as a directory.
-func NewDir(name string) *Tree {
-	return &Tree{Name: name, IsDir: true}
+func NewDir(name string) *Node {
+	return &Node{Name: name, IsDir: true}
 }
 
 // NewFile creates a tree node.
-func NewFile(name string) *Tree {
-	return &Tree{Name: name}
+func NewFile(name string) *Node {
+	return &Node{Name: name}
 }
 
 // Add appends the provided tree nodes to the node's children.
 //
 // Unlike AddFile and AddDir, Add returns the original node for
 // chaining.
-func (t *Tree) Add(trees ...*Tree) *Tree {
-	for _, tree := range trees {
+func (t *Node) Add(nodes ...*Node) *Node {
+	for _, tree := range nodes {
 		t.Children = append(t.Children, tree)
 	}
 	return t
@@ -43,7 +43,7 @@ func (t *Tree) Add(trees ...*Tree) *Tree {
 // and appends it to the node's children.
 //
 // Unlike AddDirs, AddDir returns the newly created node.
-func (t *Tree) AddDir(name string) *Tree {
+func (t *Node) AddDir(name string) *Node {
 	child := NewDir(name)
 	t.Children = append(t.Children, child)
 	return child
@@ -53,7 +53,7 @@ func (t *Tree) AddDir(name string) *Tree {
 // to be recognized as directories, and appends them to the node's children.
 //
 // Unlike AddDir, AddDirs returns the original node for chaining.
-func (t *Tree) AddDirs(names ...string) *Tree {
+func (t *Node) AddDirs(names ...string) *Node {
 	for _, name := range names {
 		child := NewDir(name)
 		t.Children = append(t.Children, child)
@@ -64,7 +64,7 @@ func (t *Tree) AddDirs(names ...string) *Tree {
 // AddFile creates a tree node and appends it to the node's children.
 //
 // Unlike AddFiles, AddFile returns the newly created node.
-func (t *Tree) AddFile(name string) *Tree {
+func (t *Node) AddFile(name string) *Node {
 	child := NewFile(name)
 	t.Children = append(t.Children, child)
 	return child
@@ -74,7 +74,7 @@ func (t *Tree) AddFile(name string) *Tree {
 // them to the node's children.
 //
 // Unlike AddFile, AddFiles returns the original node for chaining.
-func (t *Tree) AddFiles(names ...string) *Tree {
+func (t *Node) AddFiles(names ...string) *Node {
 	for _, name := range names {
 		child := NewFile(name)
 		t.Children = append(t.Children, child)
@@ -85,7 +85,7 @@ func (t *Tree) AddFiles(names ...string) *Tree {
 // Sort recursively sorts the node's children in place.
 //
 // Sort returns the original node for chaining.
-func (t *Tree) Sort(opts ...SortOption) *Tree {
+func (t *Node) Sort(opts ...SortOption) *Node {
 	options := newSortOptions(opts...)
 	sort.SliceStable(t.Children, func(i, j int) bool {
 		a := t.Children[i]
@@ -102,11 +102,11 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 }
 
 // String returns the tree's visual representation.
-func (t *Tree) String() string {
+func (t *Node) String() string {
 	return t.Name + t.printChildren("")
 }
 
-func (t *Tree) printChildren(prefix string) string {
+func (t *Node) printChildren(prefix string) string {
 	var out string
 	for i, child := range t.Children {
 		connector := "├── "
@@ -125,4 +125,4 @@ func (t *Tree) printChildren(prefix string) string {
 }
 
 // Verify that Tree implements fmt.Stringer:
-var _ fmt.Stringer = (*Tree)(nil)
+var _ fmt.Stringer = (*Node)(nil)

--- a/asciitree.go
+++ b/asciitree.go
@@ -48,11 +48,11 @@ func (t *Tree) AddDirs(names ...string) *Tree {
 	return t
 }
 
-// AddFile creates one or more tree nodes with the provided names and appends
+// AddFiles creates one or more tree nodes with the provided names and appends
 // them to the node's children.
 //
-// Unlike NewChildFile, AddFile returns the original node for chaining.
-func (t *Tree) AddFile(names ...string) *Tree {
+// Unlike NewChildFile, AddFiles returns the original node for chaining.
+func (t *Tree) AddFiles(names ...string) *Tree {
 	for _, name := range names {
 		child := NewFile(name)
 		t.children = append(t.children, child)
@@ -87,7 +87,7 @@ func (t *Tree) NewChildDir(name string) *Tree {
 
 // NewChildFile creates a tree node and appends it to the node's children.
 //
-// Unlike AddFile, NewChildFile returns the newly created node.
+// Unlike AddFiles, NewChildFile returns the newly created node.
 func (t *Tree) NewChildFile(name string) *Tree {
 	child := NewFile(name)
 	t.children = append(t.children, child)

--- a/asciitree.go
+++ b/asciitree.go
@@ -25,6 +25,17 @@ func NewFile(name string) *Tree {
 	return &Tree{name: name}
 }
 
+// Add appends the provided tree nodes to the node's children.
+//
+// Unlike NewChildFile and NewChildDir, Add returns the original node for
+// chaining.
+func (t *Tree) Add(trees ...*Tree) *Tree {
+	for _, tree := range trees {
+		t.children = append(t.children, tree)
+	}
+	return t
+}
+
 // AddDirs creates one or more tree nodes with the provided names, forces them
 // to be recognized as directories, and appends them to the node's children.
 //
@@ -45,17 +56,6 @@ func (t *Tree) AddFile(names ...string) *Tree {
 	for _, name := range names {
 		child := NewFile(name)
 		t.children = append(t.children, child)
-	}
-	return t
-}
-
-// AddTrees appends the provided tree nodes to the node's children.
-//
-// Unlike NewChildFile and NewChildDir, AddTrees returns the original node for
-// chaining.
-func (t *Tree) AddTrees(trees ...*Tree) *Tree {
-	for _, tree := range trees {
-		t.children = append(t.children, tree)
 	}
 	return t
 }

--- a/asciitree.go
+++ b/asciitree.go
@@ -1,4 +1,4 @@
-// Package asciitree provides tools to build trees of entities and print them
+// Package asciitree provides tools to build directory trees and print them
 // using ASCII art.
 package asciitree
 
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-// Node represents a tree node.
+// Node represents a directory tree node.
 type Node struct {
-	// Name is the name of the node.
+	// Name is the name of the file (or directory) described by the node.
 	Name string
-	// IsDir identifies whether the node is a directory.
+	// IsDir identifies whether the node describes a directory.
 	IsDir bool
 	// Children is the slice of the node's children.
 	Children []*Node

--- a/asciitree.go
+++ b/asciitree.go
@@ -11,13 +11,13 @@ import (
 // Tree represents a tree node.
 type Tree struct {
 	name     string
-	forceDir bool
+	isDir    bool
 	children []*Tree
 }
 
 // NewDir creates a tree node and forces it to be recognized as a directory.
 func NewDir(name string) *Tree {
-	return &Tree{forceDir: true, name: name}
+	return &Tree{isDir: true, name: name}
 }
 
 // NewFile creates a tree node.
@@ -60,16 +60,6 @@ func (t *Tree) AddFiles(names ...string) *Tree {
 	return t
 }
 
-// IsDir reports whether the node should be recognized as a directory. This is
-// possible in two cases:
-//
-// - The node has one or more children.
-// - The node was forced to be recognized as a directory by creating it with the
-// NewDir function or the NewChildDir method.
-func (t *Tree) IsDir() bool {
-	return t.forceDir || len(t.children) > 0
-}
-
 // Name returns the node's name.
 func (t *Tree) Name() string {
 	return t.name
@@ -110,7 +100,7 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 	sort.SliceStable(t.children, func(i, j int) bool {
 		a := t.children[i]
 		b := t.children[j]
-		if options.dirsFirst && a.IsDir() && !b.IsDir() {
+		if options.dirsFirst && a.isDir && !b.isDir {
 			return true
 		}
 		return a.Name() < b.Name()

--- a/asciitree.go
+++ b/asciitree.go
@@ -12,38 +12,38 @@ import (
 type Tree struct {
 	children    []*Tree
 	forceBranch bool
-	title       string
+	name        string
 }
 
 // New creates a tree node.
-func New(title string) *Tree {
-	return &Tree{title: title}
+func New(name string) *Tree {
+	return &Tree{name: name}
 }
 
 // NewBranch creates a tree node and forces it to be recognized as a branch.
-func NewBranch(title string) *Tree {
-	return &Tree{forceBranch: true, title: title}
+func NewBranch(name string) *Tree {
+	return &Tree{forceBranch: true, name: name}
 }
 
-// Add creates one or more tree nodes with the provided titles and appends them
+// Add creates one or more tree nodes with the provided names and appends them
 // to the node's children.
 //
 // Unlike NewChild, Add returns the original node for chaining.
-func (t *Tree) Add(titles ...string) *Tree {
-	for _, title := range titles {
-		child := New(title)
+func (t *Tree) Add(names ...string) *Tree {
+	for _, name := range names {
+		child := New(name)
 		t.children = append(t.children, child)
 	}
 	return t
 }
 
-// AddBranches creates one or more tree nodes with the provided titles, forces
+// AddBranches creates one or more tree nodes with the provided names, forces
 // them to be recognized as branches, and appends them to the node's children.
 //
 // Unlike NewChildBranch, AddBranches returns the original node for chaining.
-func (t *Tree) AddBranches(titles ...string) *Tree {
-	for _, title := range titles {
-		child := NewBranch(title)
+func (t *Tree) AddBranches(names ...string) *Tree {
+	for _, name := range names {
+		child := NewBranch(name)
 		t.children = append(t.children, child)
 	}
 	return t
@@ -73,8 +73,8 @@ func (t *Tree) IsBranch() bool {
 // NewChild creates a tree node and appends it to the node's children.
 //
 // Unlike Add, NewChild returns the newly created node.
-func (t *Tree) NewChild(title string) *Tree {
-	child := New(title)
+func (t *Tree) NewChild(name string) *Tree {
+	child := New(name)
 	t.children = append(t.children, child)
 	return child
 }
@@ -83,17 +83,17 @@ func (t *Tree) NewChild(title string) *Tree {
 // and appends it to the node's children.
 //
 // Unlike AddBranches, NewChildBranch returns the newly created node.
-func (t *Tree) NewChildBranch(title string) *Tree {
-	child := NewBranch(title)
+func (t *Tree) NewChildBranch(name string) *Tree {
+	child := NewBranch(name)
 	t.children = append(t.children, child)
 	return child
 }
 
-// SetTitle sets the node's title.
+// SetName sets the node's name.
 //
-// SetTitle returns the original node for chaining.
-func (t *Tree) SetTitle(title string) *Tree {
-	t.title = title
+// SetName returns the original node for chaining.
+func (t *Tree) SetName(name string) *Tree {
+	t.name = name
 	return t
 }
 
@@ -108,7 +108,7 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 		if options.branchesFirst && a.IsBranch() && !b.IsBranch() {
 			return true
 		}
-		return a.Title() < b.Title()
+		return a.Name() < b.Name()
 	})
 	for _, child := range t.children {
 		child.Sort(opts...)
@@ -118,12 +118,12 @@ func (t *Tree) Sort(opts ...SortOption) *Tree {
 
 // String returns the tree's visual representation.
 func (t *Tree) String() string {
-	return t.Title() + t.printChildren("")
+	return t.Name() + t.printChildren("")
 }
 
-// Title returns the node's title.
-func (t *Tree) Title() string {
-	return t.title
+// Name returns the node's name.
+func (t *Tree) Name() string {
+	return t.name
 }
 
 func (t *Tree) printChildren(prefix string) string {
@@ -138,7 +138,7 @@ func (t *Tree) printChildren(prefix string) string {
 		out += "\n" +
 			prefix +
 			connector +
-			strings.ReplaceAll(child.Title(), "\n", "\n"+spacer) +
+			strings.ReplaceAll(child.Name(), "\n", "\n"+spacer) +
 			child.printChildren(prefix+spacer)
 	}
 	return out

--- a/asciitree.go
+++ b/asciitree.go
@@ -10,9 +10,9 @@ import (
 
 // Tree represents a tree node.
 type Tree struct {
-	children    []*Tree
-	forceBranch bool
 	name        string
+	forceBranch bool
+	children    []*Tree
 }
 
 // New creates a tree node.

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -12,8 +12,8 @@ func TestNewDir(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{name: "alfa", isDir: true}},
-		{"bravo", &Tree{name: "bravo", isDir: true}},
+		{"alfa", &Tree{Name: "alfa", IsDir: true}},
+		{"bravo", &Tree{Name: "bravo", IsDir: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -28,8 +28,8 @@ func TestNewFile(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{name: "alfa"}},
-		{"bravo", &Tree{name: "bravo"}},
+		{"alfa", &Tree{Name: "alfa"}},
+		{"bravo", &Tree{Name: "bravo"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -49,18 +49,18 @@ func TestTreeAdd(t *testing.T) {
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: []*Tree{NewFile("bravo"), NewDir("charlie")},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie", isDir: true},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie", IsDir: true},
 		}},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []*Tree{NewFile("charlie"), NewDir("delta")},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-			{name: "delta", isDir: true},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie"},
+			{Name: "delta", IsDir: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -82,19 +82,19 @@ func TestTreeAddDir(t *testing.T) {
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo", isDir: true},
+		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo", IsDir: true},
 		}},
-		wantChild: &Tree{name: "bravo", isDir: true},
+		wantChild: &Tree{Name: "bravo", IsDir: true},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie", isDir: true},
+		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie", IsDir: true},
 		}},
-		wantChild: &Tree{name: "charlie", isDir: true},
+		wantChild: &Tree{Name: "charlie", IsDir: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -115,18 +115,18 @@ func TestTreeAddDirs(t *testing.T) {
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo", isDir: true},
-			{name: "charlie", isDir: true},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo", IsDir: true},
+			{Name: "charlie", IsDir: true},
 		}},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie", isDir: true},
-			{name: "delta", isDir: true},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie", IsDir: true},
+			{Name: "delta", IsDir: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -148,19 +148,19 @@ func TestTreeAddFile(t *testing.T) {
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
+		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
 		}},
-		wantChild: &Tree{name: "bravo"},
+		wantChild: &Tree{Name: "bravo"},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
+		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie"},
 		}},
-		wantChild: &Tree{name: "charlie"},
+		wantChild: &Tree{Name: "charlie"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -181,56 +181,23 @@ func TestTreeAddFiles(t *testing.T) {
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie"},
 		}},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-			{name: "delta"},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo"},
+			{Name: "charlie"},
+			{Name: "delta"},
 		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.tree.AddFiles(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeName(t *testing.T) {
-	tests := []struct {
-		tree *Tree
-		want string
-	}{
-		{NewDir("alfa"), "alfa"},
-		{NewFile("bravo"), "bravo"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got := tt.tree.Name()
-			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func TestTreeSetName(t *testing.T) {
-	tests := []struct {
-		tree *Tree
-		give string
-		want *Tree
-	}{
-		{NewDir("alfa"), "bravo", &Tree{name: "bravo", isDir: true}},
-		{NewFile("charlie"), "delta", &Tree{name: "delta"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			got := tt.tree.SetName(tt.give)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -244,38 +211,38 @@ func TestTreeSort(t *testing.T) {
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo", isDir: true, children: []*Tree{
-				{name: "foxtrot", isDir: true, children: []*Tree{
-					{name: "india.txt"},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo", IsDir: true, Children: []*Tree{
+				{Name: "foxtrot", IsDir: true, Children: []*Tree{
+					{Name: "india.txt"},
 				}},
-				{name: "golf.txt"},
-				{name: "hotel", isDir: true},
+				{Name: "golf.txt"},
+				{Name: "hotel", IsDir: true},
 			}},
-			{name: "charlie.txt"},
-			{name: "delta", isDir: true},
-			{name: "echo.txt"},
-			{name: "kilo", isDir: true, children: []*Tree{
-				{name: "juliet.txt"},
+			{Name: "charlie.txt"},
+			{Name: "delta", IsDir: true},
+			{Name: "echo.txt"},
+			{Name: "kilo", IsDir: true, Children: []*Tree{
+				{Name: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithDirsFirst(true)},
-		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo", isDir: true, children: []*Tree{
-				{name: "foxtrot", isDir: true, children: []*Tree{
-					{name: "india.txt"},
+		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+			{Name: "bravo", IsDir: true, Children: []*Tree{
+				{Name: "foxtrot", IsDir: true, Children: []*Tree{
+					{Name: "india.txt"},
 				}},
-				{name: "hotel", isDir: true},
-				{name: "golf.txt"},
+				{Name: "hotel", IsDir: true},
+				{Name: "golf.txt"},
 			}},
-			{name: "delta", isDir: true},
-			{name: "kilo", isDir: true, children: []*Tree{
-				{name: "juliet.txt"},
+			{Name: "delta", IsDir: true},
+			{Name: "kilo", IsDir: true, Children: []*Tree{
+				{Name: "juliet.txt"},
 			}},
-			{name: "charlie.txt"},
-			{name: "echo.txt"},
+			{Name: "charlie.txt"},
+			{Name: "echo.txt"},
 		}},
 	}}
 	for _, tt := range tests {

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -23,17 +23,17 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestNewBranch(t *testing.T) {
+func TestNewDir(t *testing.T) {
 	tests := []struct {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{name: "alfa", forceBranch: true}},
-		{"bravo", &Tree{name: "bravo", forceBranch: true}},
+		{"alfa", &Tree{name: "alfa", forceDir: true}},
+		{"bravo", &Tree{name: "bravo", forceDir: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
-			got := NewBranch(tt.give)
+			got := NewDir(tt.give)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -71,7 +71,7 @@ func TestTreeAdd(t *testing.T) {
 	}
 }
 
-func TestTreeAddBranches(t *testing.T) {
+func TestTreeAddDirs(t *testing.T) {
 	tests := []struct {
 		name string
 		tree *Tree
@@ -82,8 +82,8 @@ func TestTreeAddBranches(t *testing.T) {
 		tree: New("alfa"),
 		give: []string{"bravo", "charlie"},
 		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", forceBranch: true},
-			{name: "charlie", forceBranch: true},
+			{name: "bravo", forceDir: true},
+			{name: "charlie", forceDir: true},
 		}},
 	}, {
 		name: "has children",
@@ -91,13 +91,13 @@ func TestTreeAddBranches(t *testing.T) {
 		give: []string{"charlie", "delta"},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
-			{name: "charlie", forceBranch: true},
-			{name: "delta", forceBranch: true},
+			{name: "charlie", forceDir: true},
+			{name: "delta", forceDir: true},
 		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.AddBranches(tt.give...)
+			got := tt.tree.AddDirs(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -135,7 +135,7 @@ func TestTreeAddTrees(t *testing.T) {
 	}
 }
 
-func TestTreeIsBranch(t *testing.T) {
+func TestTreeIsDir(t *testing.T) {
 	tests := []struct {
 		name string
 		tree *Tree
@@ -143,11 +143,11 @@ func TestTreeIsBranch(t *testing.T) {
 	}{
 		{"empty", New("alfa"), false},
 		{"has children", New("alfa").Add("bravo"), true},
-		{"forced", NewBranch("alfa"), true},
+		{"forced", NewDir("alfa"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.IsBranch()
+			got := tt.tree.IsDir()
 			assert.Equal(t, got, tt.want)
 		})
 	}
@@ -203,7 +203,7 @@ func TestTreeNewChild(t *testing.T) {
 	}
 }
 
-func TestTreeNewChildBranch(t *testing.T) {
+func TestTreeNewChildDir(t *testing.T) {
 	tests := []struct {
 		name      string
 		tree      *Tree
@@ -215,22 +215,22 @@ func TestTreeNewChildBranch(t *testing.T) {
 		tree: New("alfa"),
 		give: "bravo",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", forceBranch: true},
+			{name: "bravo", forceDir: true},
 		}},
-		wantChild: &Tree{name: "bravo", forceBranch: true},
+		wantChild: &Tree{name: "bravo", forceDir: true},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: "charlie",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
-			{name: "charlie", forceBranch: true},
+			{name: "charlie", forceDir: true},
 		}},
-		wantChild: &Tree{name: "charlie", forceBranch: true},
+		wantChild: &Tree{name: "charlie", forceDir: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChildBranch(tt.give)
+			gotChild := tt.tree.NewChildDir(tt.give)
 			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
 			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
 		})
@@ -268,10 +268,10 @@ func TestTreeSort(t *testing.T) {
 					{name: "india.txt"},
 				}},
 				{name: "golf.txt"},
-				{name: "hotel", forceBranch: true},
+				{name: "hotel", forceDir: true},
 			}},
 			{name: "charlie.txt"},
-			{name: "delta", forceBranch: true},
+			{name: "delta", forceDir: true},
 			{name: "echo.txt"},
 			{name: "kilo", children: []*Tree{
 				{name: "juliet.txt"},
@@ -279,16 +279,16 @@ func TestTreeSort(t *testing.T) {
 		}},
 	}, {
 		name: "directories before files",
-		give: []SortOption{WithBranchesFirst(true)},
+		give: []SortOption{WithDirsFirst(true)},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo", children: []*Tree{
 				{name: "foxtrot", children: []*Tree{
 					{name: "india.txt"},
 				}},
-				{name: "hotel", forceBranch: true},
+				{name: "hotel", forceDir: true},
 				{name: "golf.txt"},
 			}},
-			{name: "delta", forceBranch: true},
+			{name: "delta", forceDir: true},
 			{name: "kilo", children: []*Tree{
 				{name: "juliet.txt"},
 			}},
@@ -303,10 +303,10 @@ func TestTreeSort(t *testing.T) {
 				New("bravo").AddTrees(
 					New("golf.txt"),
 					New("foxtrot").Add("india.txt"),
-					NewBranch("hotel"),
+					NewDir("hotel"),
 				),
 				New("kilo").Add("juliet.txt"),
-				NewBranch("delta"),
+				NewDir("delta"),
 				New("echo.txt"),
 			)
 			got := tree.Sort(tt.give...)
@@ -321,11 +321,11 @@ func TestTreeString(t *testing.T) {
 		tree *Tree
 		want string
 	}{{
-		name: "single node",
+		name: "just root",
 		tree: New("alfa"),
 		want: `alfa`,
 	}, {
-		name: "branched nodes",
+		name: "nested",
 		tree: New("alfa").AddTrees(
 			New("bravo.txt"),
 			New("charlie").AddTrees(
@@ -341,7 +341,7 @@ func TestTreeString(t *testing.T) {
         ├── foxtrot.txt
         └── golf.txt`,
 	}, {
-		name: "intersected branched nodes",
+		name: "nested + intersected",
 		tree: New("alfa").AddTrees(
 			New("bravo").Add("charlie.txt"),
 			New("delta.txt"),

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -71,6 +71,40 @@ func TestTreeAdd(t *testing.T) {
 	}
 }
 
+func TestTreeAddDir(t *testing.T) {
+	tests := []struct {
+		name      string
+		tree      *Tree
+		give      string
+		wantTree  *Tree
+		wantChild *Tree
+	}{{
+		name: "empty",
+		tree: NewDir("alfa"),
+		give: "bravo",
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo", isDir: true},
+		}},
+		wantChild: &Tree{name: "bravo", isDir: true},
+	}, {
+		name: "has children",
+		tree: NewDir("alfa").AddFiles("bravo"),
+		give: "charlie",
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie", isDir: true},
+		}},
+		wantChild: &Tree{name: "charlie", isDir: true},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChild := tt.tree.AddDir(tt.give)
+			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
+			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
+		})
+	}
+}
+
 func TestTreeAddDirs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -99,6 +133,40 @@ func TestTreeAddDirs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.tree.AddDirs(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
+		})
+	}
+}
+
+func TestTreeAddFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		tree      *Tree
+		give      string
+		wantTree  *Tree
+		wantChild *Tree
+	}{{
+		name: "empty",
+		tree: NewDir("alfa"),
+		give: "bravo",
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo"},
+		}},
+		wantChild: &Tree{name: "bravo"},
+	}, {
+		name: "has children",
+		tree: NewDir("alfa").AddFiles("bravo"),
+		give: "charlie",
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+		}},
+		wantChild: &Tree{name: "charlie"},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChild := tt.tree.AddFile(tt.give)
+			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
+			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
 		})
 	}
 }
@@ -147,74 +215,6 @@ func TestTreeName(t *testing.T) {
 		t.Run(tt.want, func(t *testing.T) {
 			got := tt.tree.Name()
 			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func TestTreeNewChildDir(t *testing.T) {
-	tests := []struct {
-		name      string
-		tree      *Tree
-		give      string
-		wantTree  *Tree
-		wantChild *Tree
-	}{{
-		name: "empty",
-		tree: NewDir("alfa"),
-		give: "bravo",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo", isDir: true},
-		}},
-		wantChild: &Tree{name: "bravo", isDir: true},
-	}, {
-		name: "has children",
-		tree: NewDir("alfa").AddFiles("bravo"),
-		give: "charlie",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie", isDir: true},
-		}},
-		wantChild: &Tree{name: "charlie", isDir: true},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChildDir(tt.give)
-			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
-			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
-		})
-	}
-}
-
-func TestTreeNewChildFile(t *testing.T) {
-	tests := []struct {
-		name      string
-		tree      *Tree
-		give      string
-		wantTree  *Tree
-		wantChild *Tree
-	}{{
-		name: "empty",
-		tree: NewDir("alfa"),
-		give: "bravo",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-		}},
-		wantChild: &Tree{name: "bravo"},
-	}, {
-		name: "has children",
-		tree: NewDir("alfa").AddFiles("bravo"),
-		give: "charlie",
-		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-		}},
-		wantChild: &Tree{name: "charlie"},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChildFile(tt.give)
-			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
-			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
 		})
 	}
 }

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -39,6 +39,38 @@ func TestNewFile(t *testing.T) {
 	}
 }
 
+func TestTreeAdd(t *testing.T) {
+	tests := []struct {
+		name string
+		tree *Tree
+		give []*Tree
+		want *Tree
+	}{{
+		name: "empty",
+		tree: NewFile("alfa"),
+		give: []*Tree{NewFile("bravo"), NewFile("charlie")},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+		}},
+	}, {
+		name: "has children",
+		tree: NewFile("alfa").AddFile("bravo"),
+		give: []*Tree{NewFile("charlie"), NewFile("delta")},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+			{name: "delta"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.tree.Add(tt.give...)
+			assert.DeepEqual(t, got, tt.want, cmpOptions)
+		})
+	}
+}
+
 func TestTreeAddDirs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -98,38 +130,6 @@ func TestTreeAddFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.tree.AddFile(tt.give...)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
-func TestTreeAddTrees(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		give []*Tree
-		want *Tree
-	}{{
-		name: "empty",
-		tree: NewFile("alfa"),
-		give: []*Tree{NewFile("bravo"), NewFile("charlie")},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-		}},
-	}, {
-		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
-		give: []*Tree{NewFile("charlie"), NewFile("delta")},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-			{name: "delta"},
-		}},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.AddTrees(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -298,9 +298,9 @@ func TestTreeSort(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := NewFile("alfa").AddTrees(
+			tree := NewFile("alfa").Add(
 				NewFile("charlie.txt"),
-				NewFile("bravo").AddTrees(
+				NewFile("bravo").Add(
 					NewFile("golf.txt"),
 					NewFile("foxtrot").AddFile("india.txt"),
 					NewDir("hotel"),
@@ -326,9 +326,9 @@ func TestTreeString(t *testing.T) {
 		want: `alfa`,
 	}, {
 		name: "nested",
-		tree: NewFile("alfa").AddTrees(
+		tree: NewFile("alfa").Add(
 			NewFile("bravo.txt"),
-			NewFile("charlie").AddTrees(
+			NewFile("charlie").Add(
 				NewFile("delta.txt"),
 				NewFile("echo").AddFile("foxtrot.txt", "golf.txt"),
 			),
@@ -342,7 +342,7 @@ func TestTreeString(t *testing.T) {
         └── golf.txt`,
 	}, {
 		name: "nested + intersected",
-		tree: NewFile("alfa").AddTrees(
+		tree: NewFile("alfa").Add(
 			NewFile("bravo").AddFile("charlie.txt"),
 			NewFile("delta.txt"),
 		),

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -10,10 +10,10 @@ import (
 func TestNewDir(t *testing.T) {
 	tests := []struct {
 		give string
-		want *Tree
+		want *Node
 	}{
-		{"alfa", &Tree{Name: "alfa", IsDir: true}},
-		{"bravo", &Tree{Name: "bravo", IsDir: true}},
+		{"alfa", &Node{Name: "alfa", IsDir: true}},
+		{"bravo", &Node{Name: "bravo", IsDir: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -26,10 +26,10 @@ func TestNewDir(t *testing.T) {
 func TestNewFile(t *testing.T) {
 	tests := []struct {
 		give string
-		want *Tree
+		want *Node
 	}{
-		{"alfa", &Tree{Name: "alfa"}},
-		{"bravo", &Tree{Name: "bravo"}},
+		{"alfa", &Node{Name: "alfa"}},
+		{"bravo", &Node{Name: "bravo"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -42,22 +42,22 @@ func TestNewFile(t *testing.T) {
 func TestTreeAdd(t *testing.T) {
 	tests := []struct {
 		name string
-		tree *Tree
-		give []*Tree
-		want *Tree
+		tree *Node
+		give []*Node
+		want *Node
 	}{{
 		name: "empty",
 		tree: NewDir("alfa"),
-		give: []*Tree{NewFile("bravo"), NewDir("charlie")},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		give: []*Node{NewFile("bravo"), NewDir("charlie")},
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie", IsDir: true},
 		}},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
-		give: []*Tree{NewFile("charlie"), NewDir("delta")},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		give: []*Node{NewFile("charlie"), NewDir("delta")},
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie"},
 			{Name: "delta", IsDir: true},
@@ -74,27 +74,27 @@ func TestTreeAdd(t *testing.T) {
 func TestTreeAddDir(t *testing.T) {
 	tests := []struct {
 		name      string
-		tree      *Tree
+		tree      *Node
 		give      string
-		wantTree  *Tree
-		wantChild *Tree
+		wantTree  *Node
+		wantChild *Node
 	}{{
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		wantTree: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo", IsDir: true},
 		}},
-		wantChild: &Tree{Name: "bravo", IsDir: true},
+		wantChild: &Node{Name: "bravo", IsDir: true},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		wantTree: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie", IsDir: true},
 		}},
-		wantChild: &Tree{Name: "charlie", IsDir: true},
+		wantChild: &Node{Name: "charlie", IsDir: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -108,14 +108,14 @@ func TestTreeAddDir(t *testing.T) {
 func TestTreeAddDirs(t *testing.T) {
 	tests := []struct {
 		name string
-		tree *Tree
+		tree *Node
 		give []string
-		want *Tree
+		want *Node
 	}{{
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo", IsDir: true},
 			{Name: "charlie", IsDir: true},
 		}},
@@ -123,7 +123,7 @@ func TestTreeAddDirs(t *testing.T) {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie", IsDir: true},
 			{Name: "delta", IsDir: true},
@@ -140,27 +140,27 @@ func TestTreeAddDirs(t *testing.T) {
 func TestTreeAddFile(t *testing.T) {
 	tests := []struct {
 		name      string
-		tree      *Tree
+		tree      *Node
 		give      string
-		wantTree  *Tree
-		wantChild *Tree
+		wantTree  *Node
+		wantChild *Node
 	}{{
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		wantTree: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 		}},
-		wantChild: &Tree{Name: "bravo"},
+		wantChild: &Node{Name: "bravo"},
 	}, {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		wantTree: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie"},
 		}},
-		wantChild: &Tree{Name: "charlie"},
+		wantChild: &Node{Name: "charlie"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,14 +174,14 @@ func TestTreeAddFile(t *testing.T) {
 func TestTreeAddFiles(t *testing.T) {
 	tests := []struct {
 		name string
-		tree *Tree
+		tree *Node
 		give []string
-		want *Tree
+		want *Node
 	}{{
 		name: "empty",
 		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie"},
 		}},
@@ -189,7 +189,7 @@ func TestTreeAddFiles(t *testing.T) {
 		name: "has children",
 		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
 			{Name: "bravo"},
 			{Name: "charlie"},
 			{Name: "delta"},
@@ -207,13 +207,13 @@ func TestTreeSort(t *testing.T) {
 	tests := []struct {
 		name string
 		give []SortOption
-		want *Tree
+		want *Node
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
-			{Name: "bravo", IsDir: true, Children: []*Tree{
-				{Name: "foxtrot", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
+			{Name: "bravo", IsDir: true, Children: []*Node{
+				{Name: "foxtrot", IsDir: true, Children: []*Node{
 					{Name: "india.txt"},
 				}},
 				{Name: "golf.txt"},
@@ -222,23 +222,23 @@ func TestTreeSort(t *testing.T) {
 			{Name: "charlie.txt"},
 			{Name: "delta", IsDir: true},
 			{Name: "echo.txt"},
-			{Name: "kilo", IsDir: true, Children: []*Tree{
+			{Name: "kilo", IsDir: true, Children: []*Node{
 				{Name: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithDirsFirst(true)},
-		want: &Tree{Name: "alfa", IsDir: true, Children: []*Tree{
-			{Name: "bravo", IsDir: true, Children: []*Tree{
-				{Name: "foxtrot", IsDir: true, Children: []*Tree{
+		want: &Node{Name: "alfa", IsDir: true, Children: []*Node{
+			{Name: "bravo", IsDir: true, Children: []*Node{
+				{Name: "foxtrot", IsDir: true, Children: []*Node{
 					{Name: "india.txt"},
 				}},
 				{Name: "hotel", IsDir: true},
 				{Name: "golf.txt"},
 			}},
 			{Name: "delta", IsDir: true},
-			{Name: "kilo", IsDir: true, Children: []*Tree{
+			{Name: "kilo", IsDir: true, Children: []*Node{
 				{Name: "juliet.txt"},
 			}},
 			{Name: "charlie.txt"},
@@ -267,7 +267,7 @@ func TestTreeSort(t *testing.T) {
 func TestTreeString(t *testing.T) {
 	tests := []struct {
 		name string
-		tree *Tree
+		tree *Node
 		want string
 	}{{
 		name: "just root",
@@ -323,4 +323,4 @@ func TestTreeString(t *testing.T) {
 	}
 }
 
-var cmpOptions = cmp.AllowUnexported(Tree{})
+var cmpOptions = cmp.AllowUnexported(Node{})

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -12,8 +12,8 @@ func TestNew(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{title: "alfa"}},
-		{"bravo", &Tree{title: "bravo"}},
+		{"alfa", &Tree{name: "alfa"}},
+		{"bravo", &Tree{name: "bravo"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -28,8 +28,8 @@ func TestNewBranch(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{title: "alfa", forceBranch: true}},
-		{"bravo", &Tree{title: "bravo", forceBranch: true}},
+		{"alfa", &Tree{name: "alfa", forceBranch: true}},
+		{"bravo", &Tree{name: "bravo", forceBranch: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -49,18 +49,18 @@ func TestTreeAdd(t *testing.T) {
 		name: "empty",
 		tree: New("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-			{title: "delta"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+			{name: "delta"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -81,18 +81,18 @@ func TestTreeAddBranches(t *testing.T) {
 		name: "empty",
 		tree: New("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", forceBranch: true},
-			{title: "charlie", forceBranch: true},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo", forceBranch: true},
+			{name: "charlie", forceBranch: true},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie", forceBranch: true},
-			{title: "delta", forceBranch: true},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie", forceBranch: true},
+			{name: "delta", forceBranch: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -113,18 +113,18 @@ func TestTreeAddTrees(t *testing.T) {
 		name: "empty",
 		tree: New("alfa"),
 		give: []*Tree{New("bravo"), New("charlie")},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
 		}},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: []*Tree{New("charlie"), New("delta")},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
-			{title: "delta"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+			{name: "delta"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -153,6 +153,22 @@ func TestTreeIsBranch(t *testing.T) {
 	}
 }
 
+func TestTreeName(t *testing.T) {
+	tests := []struct {
+		tree *Tree
+		want string
+	}{
+		{New("alfa"), "alfa"},
+		{New("bravo"), "bravo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.tree.Name()
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
 func TestTreeNewChild(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -164,19 +180,19 @@ func TestTreeNewChild(t *testing.T) {
 		name: "empty",
 		tree: New("alfa"),
 		give: "bravo",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
 		}},
-		wantChild: &Tree{title: "bravo"},
+		wantChild: &Tree{name: "bravo"},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: "charlie",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie"},
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
 		}},
-		wantChild: &Tree{title: "charlie"},
+		wantChild: &Tree{name: "charlie"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -198,19 +214,19 @@ func TestTreeNewChildBranch(t *testing.T) {
 		name: "empty",
 		tree: New("alfa"),
 		give: "bravo",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", forceBranch: true},
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo", forceBranch: true},
 		}},
-		wantChild: &Tree{title: "bravo", forceBranch: true},
+		wantChild: &Tree{name: "bravo", forceBranch: true},
 	}, {
 		name: "has children",
 		tree: New("alfa").Add("bravo"),
 		give: "charlie",
-		wantTree: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo"},
-			{title: "charlie", forceBranch: true},
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie", forceBranch: true},
 		}},
-		wantChild: &Tree{title: "charlie", forceBranch: true},
+		wantChild: &Tree{name: "charlie", forceBranch: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -221,18 +237,18 @@ func TestTreeNewChildBranch(t *testing.T) {
 	}
 }
 
-func TestTreeSetTitle(t *testing.T) {
+func TestTreeSetName(t *testing.T) {
 	tests := []struct {
 		tree *Tree
 		give string
 		want *Tree
 	}{
-		{New("alfa"), "bravo", &Tree{title: "bravo"}},
-		{New("charlie"), "delta", &Tree{title: "delta"}},
+		{New("alfa"), "bravo", &Tree{name: "bravo"}},
+		{New("charlie"), "delta", &Tree{name: "delta"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
-			got := tt.tree.SetTitle(tt.give)
+			got := tt.tree.SetName(tt.give)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -246,38 +262,38 @@ func TestTreeSort(t *testing.T) {
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", children: []*Tree{
-				{title: "foxtrot", children: []*Tree{
-					{title: "india.txt"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo", children: []*Tree{
+				{name: "foxtrot", children: []*Tree{
+					{name: "india.txt"},
 				}},
-				{title: "golf.txt"},
-				{title: "hotel", forceBranch: true},
+				{name: "golf.txt"},
+				{name: "hotel", forceBranch: true},
 			}},
-			{title: "charlie.txt"},
-			{title: "delta", forceBranch: true},
-			{title: "echo.txt"},
-			{title: "kilo", children: []*Tree{
-				{title: "juliet.txt"},
+			{name: "charlie.txt"},
+			{name: "delta", forceBranch: true},
+			{name: "echo.txt"},
+			{name: "kilo", children: []*Tree{
+				{name: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithBranchesFirst(true)},
-		want: &Tree{title: "alfa", children: []*Tree{
-			{title: "bravo", children: []*Tree{
-				{title: "foxtrot", children: []*Tree{
-					{title: "india.txt"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo", children: []*Tree{
+				{name: "foxtrot", children: []*Tree{
+					{name: "india.txt"},
 				}},
-				{title: "hotel", forceBranch: true},
-				{title: "golf.txt"},
+				{name: "hotel", forceBranch: true},
+				{name: "golf.txt"},
 			}},
-			{title: "delta", forceBranch: true},
-			{title: "kilo", children: []*Tree{
-				{title: "juliet.txt"},
+			{name: "delta", forceBranch: true},
+			{name: "kilo", children: []*Tree{
+				{name: "juliet.txt"},
 			}},
-			{title: "charlie.txt"},
-			{title: "echo.txt"},
+			{name: "charlie.txt"},
+			{name: "echo.txt"},
 		}},
 	}}
 	for _, tt := range tests {
@@ -335,7 +351,7 @@ func TestTreeString(t *testing.T) {
 │   └── charlie.txt
 └── delta.txt`,
 	}, {
-		name: "multiline titles",
+		name: "multiline names",
 		tree: New("alfa\n[dir]\n[3 MB]").Add(
 			"bravo.txt\n[file]\n[1 MB]",
 			"charlie.txt\n[file]\n[2 MB]",
@@ -353,22 +369,6 @@ func TestTreeString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.tree.String()
-			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func TestTreeTitle(t *testing.T) {
-	tests := []struct {
-		tree *Tree
-		want string
-	}{
-		{New("alfa"), "alfa"},
-		{New("bravo"), "bravo"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got := tt.tree.Title()
 			assert.Equal(t, got, tt.want)
 		})
 	}

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -55,7 +55,7 @@ func TestTreeAdd(t *testing.T) {
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
+		tree: NewFile("alfa").AddFiles("bravo"),
 		give: []*Tree{NewFile("charlie"), NewFile("delta")},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -87,7 +87,7 @@ func TestTreeAddDirs(t *testing.T) {
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
+		tree: NewFile("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -103,7 +103,7 @@ func TestTreeAddDirs(t *testing.T) {
 	}
 }
 
-func TestTreeAddFile(t *testing.T) {
+func TestTreeAddFiles(t *testing.T) {
 	tests := []struct {
 		name string
 		tree *Tree
@@ -119,7 +119,7 @@ func TestTreeAddFile(t *testing.T) {
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
+		tree: NewFile("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -129,7 +129,7 @@ func TestTreeAddFile(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.AddFile(tt.give...)
+			got := tt.tree.AddFiles(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -142,7 +142,7 @@ func TestTreeIsDir(t *testing.T) {
 		want bool
 	}{
 		{"empty", NewFile("alfa"), false},
-		{"has children", NewFile("alfa").AddFile("bravo"), true},
+		{"has children", NewFile("alfa").AddFiles("bravo"), true},
 		{"forced", NewDir("alfa"), true},
 	}
 	for _, tt := range tests {
@@ -186,7 +186,7 @@ func TestTreeNewChildDir(t *testing.T) {
 		wantChild: &Tree{name: "bravo", forceDir: true},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
+		tree: NewFile("alfa").AddFiles("bravo"),
 		give: "charlie",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -220,7 +220,7 @@ func TestTreeNewChildFile(t *testing.T) {
 		wantChild: &Tree{name: "bravo"},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFile("bravo"),
+		tree: NewFile("alfa").AddFiles("bravo"),
 		give: "charlie",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -302,10 +302,10 @@ func TestTreeSort(t *testing.T) {
 				NewFile("charlie.txt"),
 				NewFile("bravo").Add(
 					NewFile("golf.txt"),
-					NewFile("foxtrot").AddFile("india.txt"),
+					NewFile("foxtrot").AddFiles("india.txt"),
 					NewDir("hotel"),
 				),
-				NewFile("kilo").AddFile("juliet.txt"),
+				NewFile("kilo").AddFiles("juliet.txt"),
 				NewDir("delta"),
 				NewFile("echo.txt"),
 			)
@@ -330,7 +330,7 @@ func TestTreeString(t *testing.T) {
 			NewFile("bravo.txt"),
 			NewFile("charlie").Add(
 				NewFile("delta.txt"),
-				NewFile("echo").AddFile("foxtrot.txt", "golf.txt"),
+				NewFile("echo").AddFiles("foxtrot.txt", "golf.txt"),
 			),
 		),
 		want: `alfa
@@ -343,7 +343,7 @@ func TestTreeString(t *testing.T) {
 	}, {
 		name: "nested + intersected",
 		tree: NewFile("alfa").Add(
-			NewFile("bravo").AddFile("charlie.txt"),
+			NewFile("bravo").AddFiles("charlie.txt"),
 			NewFile("delta.txt"),
 		),
 		want: `alfa
@@ -352,7 +352,7 @@ func TestTreeString(t *testing.T) {
 └── delta.txt`,
 	}, {
 		name: "multiline names",
-		tree: NewFile("alfa\n[dir]\n[3 MB]").AddFile(
+		tree: NewFile("alfa\n[dir]\n[3 MB]").AddFiles(
 			"bravo.txt\n[file]\n[1 MB]",
 			"charlie.txt\n[file]\n[2 MB]",
 		),

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -12,8 +12,8 @@ func TestNewDir(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{"alfa", &Tree{name: "alfa", forceDir: true}},
-		{"bravo", &Tree{name: "bravo", forceDir: true}},
+		{"alfa", &Tree{name: "alfa", isDir: true}},
+		{"bravo", &Tree{name: "bravo", isDir: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -47,20 +47,20 @@ func TestTreeAdd(t *testing.T) {
 		want *Tree
 	}{{
 		name: "empty",
-		tree: NewFile("alfa"),
-		give: []*Tree{NewFile("bravo"), NewFile("charlie")},
-		want: &Tree{name: "alfa", children: []*Tree{
+		tree: NewDir("alfa"),
+		give: []*Tree{NewFile("bravo"), NewDir("charlie")},
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
-			{name: "charlie"},
+			{name: "charlie", isDir: true},
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFiles("bravo"),
-		give: []*Tree{NewFile("charlie"), NewFile("delta")},
-		want: &Tree{name: "alfa", children: []*Tree{
+		tree: NewDir("alfa").AddFiles("bravo"),
+		give: []*Tree{NewFile("charlie"), NewDir("delta")},
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
-			{name: "delta"},
+			{name: "delta", isDir: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -79,20 +79,20 @@ func TestTreeAddDirs(t *testing.T) {
 		want *Tree
 	}{{
 		name: "empty",
-		tree: NewFile("alfa"),
+		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", forceDir: true},
-			{name: "charlie", forceDir: true},
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo", isDir: true},
+			{name: "charlie", isDir: true},
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFiles("bravo"),
+		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{name: "alfa", children: []*Tree{
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
-			{name: "charlie", forceDir: true},
-			{name: "delta", forceDir: true},
+			{name: "charlie", isDir: true},
+			{name: "delta", isDir: true},
 		}},
 	}}
 	for _, tt := range tests {
@@ -111,17 +111,17 @@ func TestTreeAddFiles(t *testing.T) {
 		want *Tree
 	}{{
 		name: "empty",
-		tree: NewFile("alfa"),
+		tree: NewDir("alfa"),
 		give: []string{"bravo", "charlie"},
-		want: &Tree{name: "alfa", children: []*Tree{
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
 		}},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFiles("bravo"),
+		tree: NewDir("alfa").AddFiles("bravo"),
 		give: []string{"charlie", "delta"},
-		want: &Tree{name: "alfa", children: []*Tree{
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
 			{name: "delta"},
@@ -135,30 +135,12 @@ func TestTreeAddFiles(t *testing.T) {
 	}
 }
 
-func TestTreeIsDir(t *testing.T) {
-	tests := []struct {
-		name string
-		tree *Tree
-		want bool
-	}{
-		{"empty", NewFile("alfa"), false},
-		{"has children", NewFile("alfa").AddFiles("bravo"), true},
-		{"forced", NewDir("alfa"), true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.IsDir()
-			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
 func TestTreeName(t *testing.T) {
 	tests := []struct {
 		tree *Tree
 		want string
 	}{
-		{NewFile("alfa"), "alfa"},
+		{NewDir("alfa"), "alfa"},
 		{NewFile("bravo"), "bravo"},
 	}
 	for _, tt := range tests {
@@ -178,21 +160,21 @@ func TestTreeNewChildDir(t *testing.T) {
 		wantChild *Tree
 	}{{
 		name: "empty",
-		tree: NewFile("alfa"),
+		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", forceDir: true},
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo", isDir: true},
 		}},
-		wantChild: &Tree{name: "bravo", forceDir: true},
+		wantChild: &Tree{name: "bravo", isDir: true},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFiles("bravo"),
+		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
-			{name: "charlie", forceDir: true},
+			{name: "charlie", isDir: true},
 		}},
-		wantChild: &Tree{name: "charlie", forceDir: true},
+		wantChild: &Tree{name: "charlie", isDir: true},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -212,17 +194,17 @@ func TestTreeNewChildFile(t *testing.T) {
 		wantChild *Tree
 	}{{
 		name: "empty",
-		tree: NewFile("alfa"),
+		tree: NewDir("alfa"),
 		give: "bravo",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
 		}},
 		wantChild: &Tree{name: "bravo"},
 	}, {
 		name: "has children",
-		tree: NewFile("alfa").AddFiles("bravo"),
+		tree: NewDir("alfa").AddFiles("bravo"),
 		give: "charlie",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
+		wantTree: &Tree{name: "alfa", isDir: true, children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
 		}},
@@ -243,7 +225,7 @@ func TestTreeSetName(t *testing.T) {
 		give string
 		want *Tree
 	}{
-		{NewFile("alfa"), "bravo", &Tree{name: "bravo"}},
+		{NewDir("alfa"), "bravo", &Tree{name: "bravo", isDir: true}},
 		{NewFile("charlie"), "delta", &Tree{name: "delta"}},
 	}
 	for _, tt := range tests {
@@ -262,34 +244,34 @@ func TestTreeSort(t *testing.T) {
 	}{{
 		name: "default",
 		give: []SortOption{},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", children: []*Tree{
-				{name: "foxtrot", children: []*Tree{
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo", isDir: true, children: []*Tree{
+				{name: "foxtrot", isDir: true, children: []*Tree{
 					{name: "india.txt"},
 				}},
 				{name: "golf.txt"},
-				{name: "hotel", forceDir: true},
+				{name: "hotel", isDir: true},
 			}},
 			{name: "charlie.txt"},
-			{name: "delta", forceDir: true},
+			{name: "delta", isDir: true},
 			{name: "echo.txt"},
-			{name: "kilo", children: []*Tree{
+			{name: "kilo", isDir: true, children: []*Tree{
 				{name: "juliet.txt"},
 			}},
 		}},
 	}, {
 		name: "directories before files",
 		give: []SortOption{WithDirsFirst(true)},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo", children: []*Tree{
-				{name: "foxtrot", children: []*Tree{
+		want: &Tree{name: "alfa", isDir: true, children: []*Tree{
+			{name: "bravo", isDir: true, children: []*Tree{
+				{name: "foxtrot", isDir: true, children: []*Tree{
 					{name: "india.txt"},
 				}},
-				{name: "hotel", forceDir: true},
+				{name: "hotel", isDir: true},
 				{name: "golf.txt"},
 			}},
-			{name: "delta", forceDir: true},
-			{name: "kilo", children: []*Tree{
+			{name: "delta", isDir: true},
+			{name: "kilo", isDir: true, children: []*Tree{
 				{name: "juliet.txt"},
 			}},
 			{name: "charlie.txt"},
@@ -298,14 +280,14 @@ func TestTreeSort(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := NewFile("alfa").Add(
+			tree := NewDir("alfa").Add(
 				NewFile("charlie.txt"),
-				NewFile("bravo").Add(
+				NewDir("bravo").Add(
 					NewFile("golf.txt"),
-					NewFile("foxtrot").AddFiles("india.txt"),
+					NewDir("foxtrot").AddFiles("india.txt"),
 					NewDir("hotel"),
 				),
-				NewFile("kilo").AddFiles("juliet.txt"),
+				NewDir("kilo").AddFiles("juliet.txt"),
 				NewDir("delta"),
 				NewFile("echo.txt"),
 			)
@@ -322,15 +304,15 @@ func TestTreeString(t *testing.T) {
 		want string
 	}{{
 		name: "just root",
-		tree: NewFile("alfa"),
+		tree: NewDir("alfa"),
 		want: `alfa`,
 	}, {
 		name: "nested",
-		tree: NewFile("alfa").Add(
+		tree: NewDir("alfa").Add(
 			NewFile("bravo.txt"),
-			NewFile("charlie").Add(
+			NewDir("charlie").Add(
 				NewFile("delta.txt"),
-				NewFile("echo").AddFiles("foxtrot.txt", "golf.txt"),
+				NewDir("echo").AddFiles("foxtrot.txt", "golf.txt"),
 			),
 		),
 		want: `alfa
@@ -342,8 +324,8 @@ func TestTreeString(t *testing.T) {
         └── golf.txt`,
 	}, {
 		name: "nested + intersected",
-		tree: NewFile("alfa").Add(
-			NewFile("bravo").AddFiles("charlie.txt"),
+		tree: NewDir("alfa").Add(
+			NewDir("bravo").AddFiles("charlie.txt"),
 			NewFile("delta.txt"),
 		),
 		want: `alfa
@@ -352,7 +334,7 @@ func TestTreeString(t *testing.T) {
 └── delta.txt`,
 	}, {
 		name: "multiline names",
-		tree: NewFile("alfa\n[dir]\n[3 MB]").AddFiles(
+		tree: NewDir("alfa\n[dir]\n[3 MB]").AddFiles(
 			"bravo.txt\n[file]\n[1 MB]",
 			"charlie.txt\n[file]\n[2 MB]",
 		),

--- a/asciitree_test.go
+++ b/asciitree_test.go
@@ -7,22 +7,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestNew(t *testing.T) {
-	tests := []struct {
-		give string
-		want *Tree
-	}{
-		{"alfa", &Tree{name: "alfa"}},
-		{"bravo", &Tree{name: "bravo"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			got := New(tt.give)
-			assert.DeepEqual(t, got, tt.want, cmpOptions)
-		})
-	}
-}
-
 func TestNewDir(t *testing.T) {
 	tests := []struct {
 		give string
@@ -39,33 +23,17 @@ func TestNewDir(t *testing.T) {
 	}
 }
 
-func TestTreeAdd(t *testing.T) {
+func TestNewFile(t *testing.T) {
 	tests := []struct {
-		name string
-		tree *Tree
-		give []string
+		give string
 		want *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: []string{"bravo", "charlie"},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-		}},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: []string{"charlie", "delta"},
-		want: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-			{name: "delta"},
-		}},
-	}}
+	}{
+		{"alfa", &Tree{name: "alfa"}},
+		{"bravo", &Tree{name: "bravo"}},
+	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.tree.Add(tt.give...)
+		t.Run(tt.give, func(t *testing.T) {
+			got := NewFile(tt.give)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
 		})
 	}
@@ -79,7 +47,7 @@ func TestTreeAddDirs(t *testing.T) {
 		want *Tree
 	}{{
 		name: "empty",
-		tree: New("alfa"),
+		tree: NewFile("alfa"),
 		give: []string{"bravo", "charlie"},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo", forceDir: true},
@@ -87,7 +55,7 @@ func TestTreeAddDirs(t *testing.T) {
 		}},
 	}, {
 		name: "has children",
-		tree: New("alfa").Add("bravo"),
+		tree: NewFile("alfa").AddFile("bravo"),
 		give: []string{"charlie", "delta"},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -103,6 +71,38 @@ func TestTreeAddDirs(t *testing.T) {
 	}
 }
 
+func TestTreeAddFile(t *testing.T) {
+	tests := []struct {
+		name string
+		tree *Tree
+		give []string
+		want *Tree
+	}{{
+		name: "empty",
+		tree: NewFile("alfa"),
+		give: []string{"bravo", "charlie"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+		}},
+	}, {
+		name: "has children",
+		tree: NewFile("alfa").AddFile("bravo"),
+		give: []string{"charlie", "delta"},
+		want: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+			{name: "delta"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.tree.AddFile(tt.give...)
+			assert.DeepEqual(t, got, tt.want, cmpOptions)
+		})
+	}
+}
+
 func TestTreeAddTrees(t *testing.T) {
 	tests := []struct {
 		name string
@@ -111,16 +111,16 @@ func TestTreeAddTrees(t *testing.T) {
 		want *Tree
 	}{{
 		name: "empty",
-		tree: New("alfa"),
-		give: []*Tree{New("bravo"), New("charlie")},
+		tree: NewFile("alfa"),
+		give: []*Tree{NewFile("bravo"), NewFile("charlie")},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
 		}},
 	}, {
 		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: []*Tree{New("charlie"), New("delta")},
+		tree: NewFile("alfa").AddFile("bravo"),
+		give: []*Tree{NewFile("charlie"), NewFile("delta")},
 		want: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
 			{name: "charlie"},
@@ -141,8 +141,8 @@ func TestTreeIsDir(t *testing.T) {
 		tree *Tree
 		want bool
 	}{
-		{"empty", New("alfa"), false},
-		{"has children", New("alfa").Add("bravo"), true},
+		{"empty", NewFile("alfa"), false},
+		{"has children", NewFile("alfa").AddFile("bravo"), true},
 		{"forced", NewDir("alfa"), true},
 	}
 	for _, tt := range tests {
@@ -158,47 +158,13 @@ func TestTreeName(t *testing.T) {
 		tree *Tree
 		want string
 	}{
-		{New("alfa"), "alfa"},
-		{New("bravo"), "bravo"},
+		{NewFile("alfa"), "alfa"},
+		{NewFile("bravo"), "bravo"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
 			got := tt.tree.Name()
 			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func TestTreeNewChild(t *testing.T) {
-	tests := []struct {
-		name      string
-		tree      *Tree
-		give      string
-		wantTree  *Tree
-		wantChild *Tree
-	}{{
-		name: "empty",
-		tree: New("alfa"),
-		give: "bravo",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-		}},
-		wantChild: &Tree{name: "bravo"},
-	}, {
-		name: "has children",
-		tree: New("alfa").Add("bravo"),
-		give: "charlie",
-		wantTree: &Tree{name: "alfa", children: []*Tree{
-			{name: "bravo"},
-			{name: "charlie"},
-		}},
-		wantChild: &Tree{name: "charlie"},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotChild := tt.tree.NewChild(tt.give)
-			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
-			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
 		})
 	}
 }
@@ -212,7 +178,7 @@ func TestTreeNewChildDir(t *testing.T) {
 		wantChild *Tree
 	}{{
 		name: "empty",
-		tree: New("alfa"),
+		tree: NewFile("alfa"),
 		give: "bravo",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo", forceDir: true},
@@ -220,7 +186,7 @@ func TestTreeNewChildDir(t *testing.T) {
 		wantChild: &Tree{name: "bravo", forceDir: true},
 	}, {
 		name: "has children",
-		tree: New("alfa").Add("bravo"),
+		tree: NewFile("alfa").AddFile("bravo"),
 		give: "charlie",
 		wantTree: &Tree{name: "alfa", children: []*Tree{
 			{name: "bravo"},
@@ -237,14 +203,48 @@ func TestTreeNewChildDir(t *testing.T) {
 	}
 }
 
+func TestTreeNewChildFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		tree      *Tree
+		give      string
+		wantTree  *Tree
+		wantChild *Tree
+	}{{
+		name: "empty",
+		tree: NewFile("alfa"),
+		give: "bravo",
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+		}},
+		wantChild: &Tree{name: "bravo"},
+	}, {
+		name: "has children",
+		tree: NewFile("alfa").AddFile("bravo"),
+		give: "charlie",
+		wantTree: &Tree{name: "alfa", children: []*Tree{
+			{name: "bravo"},
+			{name: "charlie"},
+		}},
+		wantChild: &Tree{name: "charlie"},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChild := tt.tree.NewChildFile(tt.give)
+			assert.DeepEqual(t, tt.tree, tt.wantTree, cmpOptions)
+			assert.DeepEqual(t, gotChild, tt.wantChild, cmpOptions)
+		})
+	}
+}
+
 func TestTreeSetName(t *testing.T) {
 	tests := []struct {
 		tree *Tree
 		give string
 		want *Tree
 	}{
-		{New("alfa"), "bravo", &Tree{name: "bravo"}},
-		{New("charlie"), "delta", &Tree{name: "delta"}},
+		{NewFile("alfa"), "bravo", &Tree{name: "bravo"}},
+		{NewFile("charlie"), "delta", &Tree{name: "delta"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.give, func(t *testing.T) {
@@ -298,16 +298,16 @@ func TestTreeSort(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := New("alfa").AddTrees(
-				New("charlie.txt"),
-				New("bravo").AddTrees(
-					New("golf.txt"),
-					New("foxtrot").Add("india.txt"),
+			tree := NewFile("alfa").AddTrees(
+				NewFile("charlie.txt"),
+				NewFile("bravo").AddTrees(
+					NewFile("golf.txt"),
+					NewFile("foxtrot").AddFile("india.txt"),
 					NewDir("hotel"),
 				),
-				New("kilo").Add("juliet.txt"),
+				NewFile("kilo").AddFile("juliet.txt"),
 				NewDir("delta"),
-				New("echo.txt"),
+				NewFile("echo.txt"),
 			)
 			got := tree.Sort(tt.give...)
 			assert.DeepEqual(t, got, tt.want, cmpOptions)
@@ -322,15 +322,15 @@ func TestTreeString(t *testing.T) {
 		want string
 	}{{
 		name: "just root",
-		tree: New("alfa"),
+		tree: NewFile("alfa"),
 		want: `alfa`,
 	}, {
 		name: "nested",
-		tree: New("alfa").AddTrees(
-			New("bravo.txt"),
-			New("charlie").AddTrees(
-				New("delta.txt"),
-				New("echo").Add("foxtrot.txt", "golf.txt"),
+		tree: NewFile("alfa").AddTrees(
+			NewFile("bravo.txt"),
+			NewFile("charlie").AddTrees(
+				NewFile("delta.txt"),
+				NewFile("echo").AddFile("foxtrot.txt", "golf.txt"),
 			),
 		),
 		want: `alfa
@@ -342,9 +342,9 @@ func TestTreeString(t *testing.T) {
         └── golf.txt`,
 	}, {
 		name: "nested + intersected",
-		tree: New("alfa").AddTrees(
-			New("bravo").Add("charlie.txt"),
-			New("delta.txt"),
+		tree: NewFile("alfa").AddTrees(
+			NewFile("bravo").AddFile("charlie.txt"),
+			NewFile("delta.txt"),
 		),
 		want: `alfa
 ├── bravo
@@ -352,7 +352,7 @@ func TestTreeString(t *testing.T) {
 └── delta.txt`,
 	}, {
 		name: "multiline names",
-		tree: New("alfa\n[dir]\n[3 MB]").Add(
+		tree: NewFile("alfa\n[dir]\n[3 MB]").AddFile(
 			"bravo.txt\n[file]\n[1 MB]",
 			"charlie.txt\n[file]\n[2 MB]",
 		),

--- a/options.go
+++ b/options.go
@@ -1,24 +1,24 @@
 package asciitree
 
+type sortOptions struct {
+	dirsFirst bool
+}
+
 // SortOption represents an option that can be provided to the Sort method.
 type SortOption interface {
 	apply(*sortOptions)
 }
 
-type sortOptions struct {
-	dirsFirst bool
-}
-
 type dirsFirstOption bool
+
+func (d dirsFirstOption) apply(opts *sortOptions) {
+	opts.dirsFirst = bool(d)
+}
 
 // WithDirsFirst is an option that makes the Sort method order directories
 // before leaves.
 func WithDirsFirst(value bool) SortOption {
 	return dirsFirstOption(value)
-}
-
-func (d dirsFirstOption) apply(opts *sortOptions) {
-	opts.dirsFirst = bool(d)
 }
 
 func newSortOptions(opts ...SortOption) sortOptions {

--- a/options.go
+++ b/options.go
@@ -6,19 +6,19 @@ type SortOption interface {
 }
 
 type sortOptions struct {
-	branchesFirst bool
+	dirsFirst bool
 }
 
-type branchesFirstOption bool
+type dirsFirstOption bool
 
-// WithBranchesFirst is an option that makes the Sort method order branches
+// WithDirsFirst is an option that makes the Sort method order directories
 // before leaves.
-func WithBranchesFirst(value bool) SortOption {
-	return branchesFirstOption(value)
+func WithDirsFirst(value bool) SortOption {
+	return dirsFirstOption(value)
 }
 
-func (d branchesFirstOption) apply(opts *sortOptions) {
-	opts.branchesFirst = bool(d)
+func (d dirsFirstOption) apply(opts *sortOptions) {
+	opts.dirsFirst = bool(d)
 }
 
 func newSortOptions(opts ...SortOption) sortOptions {
@@ -29,5 +29,5 @@ func newSortOptions(opts ...SortOption) sortOptions {
 	return options
 }
 
-// Verify that branchesFirstOption implements asciitree.SortOption
-var _ SortOption = (*branchesFirstOption)(nil)
+// Verify that dirsFirstOption implements asciitree.SortOption
+var _ SortOption = (*dirsFirstOption)(nil)


### PR DESCRIPTION
This PR:

- Uses "Files/Directories" terminology instead of "Leaves/Branches".
- Renames `NewChild<noun>` to `Add<noun>`.
- Exports the methods of the `Node` struct.